### PR TITLE
feat: Refactor bindings to use typed ViewModel for improved type safety

### DIFF
--- a/packages/core/src/bindings/bindClass.test.ts
+++ b/packages/core/src/bindings/bindClass.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { setupClassBindings, renderClassBindings } from "./bindClass";
+import type { ViewModel } from "./types";
 
 describe("bindClass", () => {
   let container: HTMLElement;
@@ -160,7 +161,7 @@ describe("bindClass", () => {
 
     it("should handle invalid values", () => {
       container.innerHTML = '<div class="static" bind-class="classes"></div>';
-      const viewModel: any = { classes: null };
+      const viewModel: ViewModel<{ classes: unknown }> = { classes: null };
       const bindings = setupClassBindings(container, viewModel);
 
       renderClassBindings(bindings, viewModel);

--- a/packages/core/src/bindings/bindClass.ts
+++ b/packages/core/src/bindings/bindClass.ts
@@ -1,9 +1,9 @@
-import type { ClassBinding } from "./types";
+import type { ClassBinding, ViewModel } from "./types";
 import { assertViewModelProperty } from "../validation/assertViewModelProperty";
 
-export function setupClassBindings(
+export function setupClassBindings<T extends object>(
   root: HTMLElement,
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): ClassBinding[] {
   const bindings: ClassBinding[] = [];
   const elements = root.querySelectorAll<HTMLElement>("[bind-class]");
@@ -24,12 +24,12 @@ export function setupClassBindings(
   return bindings;
 }
 
-export function renderClassBindings(
+export function renderClassBindings<T extends object>(
   bindings: ClassBinding[],
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): void {
   for (const binding of bindings) {
-    const value = (viewModel as any)[binding.propertyName];
+    const value = viewModel[binding.propertyName];
 
     const staticClasses = binding.staticClassName.trim();
     let dynamicClasses = "";

--- a/packages/core/src/bindings/bindClick.ts
+++ b/packages/core/src/bindings/bindClick.ts
@@ -1,4 +1,9 @@
-export function setupClickBindings(root: HTMLElement, viewModel: any): void {
+import type { ViewModel } from "./types";
+
+export function setupClickBindings<T extends object>(
+  root: HTMLElement,
+  viewModel: ViewModel<T>,
+): void {
   const elements = root.querySelectorAll<HTMLElement>("[click]");
 
   for (const element of elements) {
@@ -6,7 +11,7 @@ export function setupClickBindings(root: HTMLElement, viewModel: any): void {
     if (!handlerName) continue;
 
     element.addEventListener("click", (event) => {
-      const handler = (viewModel as any)[handlerName];
+      const handler = viewModel[handlerName];
 
       if (typeof handler !== "function") {
         throw new Error(

--- a/packages/core/src/bindings/bindIf.test.ts
+++ b/packages/core/src/bindings/bindIf.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { setupIfBindings, renderIfBindings } from "./bindIf";
+import type { ViewModel } from "./types";
 
 describe("bindIf", () => {
   let container: HTMLElement;
@@ -89,7 +90,7 @@ describe("bindIf", () => {
 
     it("should treat falsy values as false", () => {
       container.innerHTML = '<div if="value"></div>';
-      const viewModel: any = { value: 0 };
+      const viewModel: ViewModel<{ value: unknown }> = { value: 0 };
       const bindings = setupIfBindings(container, viewModel);
 
       renderIfBindings(bindings, viewModel);
@@ -106,7 +107,7 @@ describe("bindIf", () => {
 
     it("should treat truthy values as true", () => {
       container.innerHTML = '<div if="value"></div>';
-      const viewModel: any = { value: 1 };
+      const viewModel: ViewModel<{ value: unknown }> = { value: 1 };
       const bindings = setupIfBindings(container, viewModel);
 
       renderIfBindings(bindings, viewModel);

--- a/packages/core/src/bindings/bindIf.ts
+++ b/packages/core/src/bindings/bindIf.ts
@@ -1,9 +1,9 @@
-import type { IfBinding } from "./types";
+import type { IfBinding, ViewModel } from "./types";
 import { assertViewModelProperty } from "../validation/assertViewModelProperty";
 
-export function setupIfBindings(
+export function setupIfBindings<T extends object>(
   root: HTMLElement,
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): IfBinding[] {
   const bindings: IfBinding[] = [];
   const elements = root.querySelectorAll<HTMLElement>("[if]");
@@ -24,12 +24,12 @@ export function setupIfBindings(
   return bindings;
 }
 
-export function renderIfBindings(
+export function renderIfBindings<T extends object>(
   bindings: IfBinding[],
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): void {
   for (const binding of bindings) {
-    const value = (viewModel as any)[binding.propertyName];
+    const value = viewModel[binding.propertyName];
     const shouldShow = Boolean(value);
 
     binding.element.style.display = shouldShow

--- a/packages/core/src/bindings/bindStyle.test.ts
+++ b/packages/core/src/bindings/bindStyle.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { setupStyleBindings, renderStyleBindings } from "./bindStyle";
+import type { ViewModel } from "./types";
 
 describe("bindStyle", () => {
   let container: HTMLElement;
@@ -105,7 +106,7 @@ describe("bindStyle", () => {
 
     it("should clear styles when value is not an object", () => {
       container.innerHTML = '<div bind-style="styles" style="color: red;"></div>';
-      const viewModel: any = { styles: null };
+      const viewModel: ViewModel<{ styles: unknown }> = { styles: null };
       const bindings = setupStyleBindings(container, viewModel);
 
       renderStyleBindings(bindings, viewModel);
@@ -116,7 +117,7 @@ describe("bindStyle", () => {
 
     it("should update styles when object changes", () => {
       container.innerHTML = '<div bind-style="styles"></div>';
-      const viewModel: any = {
+      const viewModel: ViewModel<{ styles: unknown }> = {
         styles: {
           color: "red",
         },
@@ -138,7 +139,7 @@ describe("bindStyle", () => {
 
     it("should replace all styles on each render", () => {
       container.innerHTML = '<div bind-style="styles"></div>';
-      const viewModel: any = {
+      const viewModel: ViewModel<{ styles: unknown }> = {
         styles: {
           color: "red",
           fontSize: "16px",

--- a/packages/core/src/bindings/bindStyle.ts
+++ b/packages/core/src/bindings/bindStyle.ts
@@ -1,9 +1,9 @@
-import type { StyleBinding } from "./types";
+import type { StyleBinding, ViewModel } from "./types";
 import { assertViewModelProperty } from "../validation/assertViewModelProperty";
 
-export function setupStyleBindings(
+export function setupStyleBindings<T extends object>(
   root: HTMLElement,
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): StyleBinding[] {
   const bindings: StyleBinding[] = [];
   const elements = root.querySelectorAll<HTMLElement>("[bind-style]");
@@ -23,12 +23,12 @@ export function setupStyleBindings(
   return bindings;
 }
 
-export function renderStyleBindings(
+export function renderStyleBindings<T extends object>(
   bindings: StyleBinding[],
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): void {
   for (const binding of bindings) {
-    const value = (viewModel as any)[binding.propertyName];
+    const value = viewModel[binding.propertyName];
 
     if (!value || typeof value !== "object") {
       binding.element.removeAttribute("style");

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { setupValueBindings, renderValueBindings } from "./bindValue";
+import type { ViewModel } from "./types";
 
 describe("bindValue", () => {
   let container: HTMLElement;
@@ -126,7 +127,7 @@ describe("bindValue", () => {
 
     it("should handle null and undefined values", () => {
       container.innerHTML = '<span bind-value="text"></span>';
-      const viewModel: any = { text: "initial" };
+      const viewModel: ViewModel<{ text: unknown }> = { text: "initial" };
       const bindings = setupValueBindings(container, viewModel);
 
       viewModel.text = null;

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -1,9 +1,9 @@
-import type { ValueBinding } from "./types";
+import type { ValueBinding, ViewModel } from "./types";
 import { assertViewModelProperty } from "../validation/assertViewModelProperty";
 
-export function setupValueBindings(
+export function setupValueBindings<T extends object>(
   root: HTMLElement,
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): ValueBinding[] {
   const bindings: ValueBinding[] = [];
   const elements = root.querySelectorAll<HTMLElement>("[bind-value]");
@@ -23,15 +23,15 @@ export function setupValueBindings(
     if (isInput) {
       element.addEventListener("input", (event) => {
         const target = event.target as HTMLInputElement | HTMLTextAreaElement;
-        const currentValue = (viewModel as any)[propertyName];
+        const currentValue = viewModel[propertyName];
 
         if (typeof currentValue === "number") {
           const numeric = Number(target.value.replace(",", "."));
-          (viewModel as any)[propertyName] = Number.isNaN(numeric)
+          viewModel[propertyName] = Number.isNaN(numeric)
             ? 0
             : numeric;
         } else {
-          (viewModel as any)[propertyName] = target.value;
+          viewModel[propertyName] = target.value;
         }
       });
     }
@@ -40,12 +40,12 @@ export function setupValueBindings(
   return bindings;
 }
 
-export function renderValueBindings(
+export function renderValueBindings<T extends object>(
   bindings: ValueBinding[],
-  viewModel: any,
+  viewModel: ViewModel<T>,
 ): void {
   for (const binding of bindings) {
-    const value = (viewModel as any)[binding.propertyName];
+    const value = viewModel[binding.propertyName];
 
     if (binding.isInput) {
       const input = binding.element as HTMLInputElement | HTMLTextAreaElement;

--- a/packages/core/src/bindings/setupBindings.ts
+++ b/packages/core/src/bindings/setupBindings.ts
@@ -1,11 +1,14 @@
-import type { BindingsCollection } from "./types";
+import type { BindingsCollection, ViewModel } from "./types";
 import { setupValueBindings, renderValueBindings } from "./bindValue";
 import { setupIfBindings, renderIfBindings } from "./bindIf";
 import { setupClassBindings, renderClassBindings } from "./bindClass";
 import { setupStyleBindings, renderStyleBindings } from "./bindStyle";
 import { setupClickBindings } from "./bindClick";
 
-export function setupBindings(root: HTMLElement, viewModel: any): () => void {
+export function setupBindings<T extends object>(
+  root: HTMLElement,
+  viewModel: ViewModel<T>,
+): () => void {
   const bindings: BindingsCollection = {
     valueBindings: setupValueBindings(root, viewModel),
     ifBindings: setupIfBindings(root, viewModel),

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -1,3 +1,7 @@
+export type ViewModel<T extends object = object> = T & {
+  [key: string]: unknown;
+};
+
 export type ValueBinding = {
   element: HTMLElement;
   propertyName: string;

--- a/packages/core/src/validation/assertViewModelProperty.ts
+++ b/packages/core/src/validation/assertViewModelProperty.ts
@@ -1,5 +1,5 @@
-export function assertViewModelProperty(
-  viewModel: any,
+export function assertViewModelProperty<T extends object>(
+  viewModel: T,
   propertyName: string,
   kind: string,
   element: Element,


### PR DESCRIPTION
# Closes #7 

```ts
export type ViewModel<T extends object = object> = T & {
  [key: string]: unknown;
};
```