### PR TITLE
chore: add initial Codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,8 @@ coverage:
   status:
     project:
       default:
-        # Allow coverage to drop by up to 5% before failing (permisive for early development)
-        threshold: 5%
+        # Allow coverage to drop by up to 10% before failing (permisive for early development)
+        threshold: 10%
         # Only fail if the coverage change is significant enough
         informational: false
     patch:


### PR DESCRIPTION
  ## Resumen
  Agrega configuración de Codecov con umbrales permisivos apropiados para la etapa de desarrollo temprano del proyecto.
  
  Closes #34 

  ## Cambios
  - Agrega `.codecov.yml` con:
    - Umbral de ~5%~ 10% para bajas en cobertura general
    - Objetivo de 30% para nuevos cambios
    - Permite iteración rápida sin bloqueos por bajas mínimas de cobertura

  ## Motivación
  Los checks de Codecov están fallando en PRs válidos (#31) debido a bajas mínimas de cobertura. Esta configuración permite desarrollo ágil mientras mantenemos visibilidad sobre la cobertura.