### PR TITLE
Refactor: rename github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Una pavada, pero me parece más correcto que se llame CI en vez de build. 

Si se les ocurre otro nombre mejor lo puedo cambiar obviamente.

Fixes #43