### PR TITLE
feat: support indexed for-each syntax and update VSCode tooling

### DIFF
--- a/docs/04-bindings/01-binding-system.md
+++ b/docs/04-bindings/01-binding-system.md
@@ -231,12 +231,14 @@ export type StyleBinding = {
 export type ForEachBinding = {
   collectionName: string;
   itemName: string;
+  indexName?: string;
   template: HTMLElement;
   placeholder: Comment;
   renderedElements: {
     element: HTMLElement;
     viewModel: ViewModel;
     itemRef: { current: any };
+    indexRef: { current: number };
     render: () => void;
   }[];
   previousLength: number;
@@ -245,7 +247,9 @@ export type ForEachBinding = {
 
 **Propósito:** Renderizar listas de elementos.
 
-**Atributo HTML:** `for-each="item of collection"`
+**Atributo HTML:** `for-each="item of collection"` o `for-each="(item, index) of collection"`
+
+**Nota:** El índice es base 0 y configurable (`index`, `i`, `idx`, etc.). La reconciliación es por posición (sin `key`).
 
 ## Fase 1: Setup de Bindings
 
@@ -1079,4 +1083,3 @@ La combinación de setup → registro → render inicial → renders selectivos 
 - [Arquitectura General](../01-architecture/01-general-architecture.md)
 - [Sistema de Reactividad](../03-reactivity/01-reactive-proxy.md)
 - [Bootstrap Process](../02-bootstrap/01-bootstrap-process.md)
-

--- a/docs/04-bindings/08-for-each.md
+++ b/docs/04-bindings/08-for-each.md
@@ -117,20 +117,16 @@ function parseForEachExpression(expression: string): {
 ### Regex Breakdown
 
 ```
+Sintaxis clásica:
 /^(\w+)\s+of\s+(\w+)$/
-o
-/^\(\s*(\w+)\s*,\s*(\w+)\s*\)\s+of\s+(\w+)$/
+Grupo 1: itemName
+Grupo 2: collectionName
 
-^           - Inicio de string
-\(\s*(\w+)  - Grupo 1: itemName (sintaxis con índice)
-\s*,\s*(\w+) - Grupo 2: indexName (sintaxis con índice)
-\s*\)\s+of\s+(\w+) - Grupo 3: collectionName (sintaxis con índice)
-(\w+)       - Grupo 1: itemName (sintaxis clásica)
-\s+         - Uno o más espacios
-of          - Literal "of"
-\s+         - Uno o más espacios
-(\w+)       - Grupo 2: collectionName (sintaxis clásica)
-$           - Fin de string
+Sintaxis con índice:
+/^\(\s*(\w+)\s*,\s*(\w+)\s*\)\s+of\s+(\w+)$/
+Grupo 1: itemName
+Grupo 2: indexName
+Grupo 3: collectionName
 ```
 
 ### Ejemplos de Parsing

--- a/docs/04-bindings/08-for-each.md
+++ b/docs/04-bindings/08-for-each.md
@@ -361,7 +361,10 @@ function createExtendedViewModel<T extends object>(
       },
       get(_target, prop) {
         if (indexName && prop === indexName) {
-          return indexRef?.current ?? 0;
+          if (!indexRef) {
+            throw new Error("indexRef is required when using indexName");
+          }
+          return indexRef.current;
         }
         if (prop === itemName) {
           return itemRef.current;

--- a/docs/04-bindings/08-for-each.md
+++ b/docs/04-bindings/08-for-each.md
@@ -37,12 +37,21 @@ El binding `for-each` es el más complejo y poderoso de PelelaJS. Permite render
 <elemento for-each="itemName of collectionName">
   <!-- Template que se repite por cada item -->
 </elemento>
+
+<elemento for-each="(itemName, indexName) of collectionName">
+  <!-- Template que se repite por cada item -->
+</elemento>
 ```
 
 ### Ejemplos
 
 ```html
 <div for-each="todo of todos">
+  <span bind-value="todo.title"></span>
+</div>
+
+<div for-each="(todo, index) of todos">
+  <span bind-value="index"></span>
   <span bind-value="todo.title"></span>
 </div>
 
@@ -62,12 +71,14 @@ El binding `for-each` es el más complejo y poderoso de PelelaJS. Permite render
 export type ForEachBinding = {
   collectionName: string;
   itemName: string;
+  indexName?: string;
   template: HTMLElement;
   placeholder: Comment;
   renderedElements: {
     element: HTMLElement;
     viewModel: ViewModel;
     itemRef: { current: any };
+    indexRef: { current: number };
     render: () => void;
   }[];
   previousLength: number;
@@ -81,8 +92,19 @@ export type ForEachBinding = {
 ```typescript
 function parseForEachExpression(expression: string): {
   itemName: string;
+  indexName?: string;
   collectionName: string;
 } | null {
+  const indexedMatch = expression
+    .trim()
+    .match(/^\(\s*(\w+)\s*,\s*(\w+)\s*\)\s+of\s+(\w+)$/);
+  if (indexedMatch) {
+    return {
+      itemName: indexedMatch[1],
+      indexName: indexedMatch[2],
+      collectionName: indexedMatch[3],
+    };
+  }
   const match = expression.trim().match(/^(\w+)\s+of\s+(\w+)$/);
   if (!match) return null;
   return {
@@ -96,13 +118,18 @@ function parseForEachExpression(expression: string): {
 
 ```
 /^(\w+)\s+of\s+(\w+)$/
+o
+/^\(\s*(\w+)\s*,\s*(\w+)\s*\)\s+of\s+(\w+)$/
 
 ^           - Inicio de string
-(\w+)       - Grupo 1: itemName (uno o más word chars)
+\(\s*(\w+)  - Grupo 1: itemName (sintaxis con índice)
+\s*,\s*(\w+) - Grupo 2: indexName (sintaxis con índice)
+\s*\)\s+of\s+(\w+) - Grupo 3: collectionName (sintaxis con índice)
+(\w+)       - Grupo 1: itemName (sintaxis clásica)
 \s+         - Uno o más espacios
 of          - Literal "of"
 \s+         - Uno o más espacios
-(\w+)       - Grupo 2: collectionName
+(\w+)       - Grupo 2: collectionName (sintaxis clásica)
 $           - Fin de string
 ```
 
@@ -135,7 +162,21 @@ match[2] = "items"
 Result: { itemName: "item", collectionName: "items" }
 ```
 
-#### Ejemplo 3: Inválido - Falta "of"
+#### Ejemplo 3: Con Índice
+
+```typescript
+parseForEachExpression("(todo, i) of todos")
+```
+
+```
+match[1] = "todo"      → itemName
+match[2] = "i"         → indexName
+match[3] = "todos"     → collectionName
+
+Result: { itemName: "todo", indexName: "i", collectionName: "todos" }
+```
+
+#### Ejemplo 4: Inválido - Falta "of"
 
 ```typescript
 parseForEachExpression("item items")
@@ -167,7 +208,7 @@ throw Error: Invalid for-each expression: "item name of items"
 setupSingleForEachBinding(element, viewModel)
     │
     ├─► 1. PARSING
-    │      parseForEachExpression("item of collection")
+    │      parseForEachExpression("item of collection" | "(item, index) of collection")
     │        └─► { itemName, collectionName }
     │
     ├─► 2. VALIDACIÓN
@@ -180,6 +221,7 @@ setupSingleForEachBinding(element, viewModel)
     │
     ├─► 4. PLACEHOLDER
     │      Crear comment node: <!-- for-each: item of collection -->
+    │      o <!-- for-each: (item, index) of collection -->
     │
     ├─► 5. REEMPLAZO
     │      Insertar placeholder antes del elemento
@@ -209,7 +251,7 @@ function setupSingleForEachBinding<T extends object>(
   const parsed = parseForEachExpression(expression);
   if (!parsed) {
     throw new Error(
-      `[pelela] Invalid for-each expression: "${expression}". Expected format: "item of collection"`,
+      `[pelela] Invalid for-each expression: "${expression}". Expected format: "item of collection" or "(item, index) of collection"`,
     );
   }
 
@@ -303,11 +345,14 @@ function createExtendedViewModel<T extends object>(
   parentViewModel: ViewModel<T>,
   itemName: string,
   itemRef: { current: any },
+  indexName?: string,
+  indexRef?: { current: number },
 ): ViewModel {
   return new Proxy(
     {},
     {
       has(_target, prop) {
+        if (indexName && prop === indexName) return true;
         if (prop === itemName) return true;
         if (typeof prop === "string" && prop.startsWith(itemName + ".")) {
           return true;
@@ -315,6 +360,9 @@ function createExtendedViewModel<T extends object>(
         return prop in parentViewModel;
       },
       get(_target, prop) {
+        if (indexName && prop === indexName) {
+          return indexRef?.current ?? 0;
+        }
         if (prop === itemName) {
           return itemRef.current;
         }
@@ -325,6 +373,9 @@ function createExtendedViewModel<T extends object>(
         return parentViewModel[prop as string];
       },
       set(_target, prop, value) {
+        if (indexName && prop === indexName) {
+          return true; // index es read-only
+        }
         if (prop === itemName) {
           itemRef.current = value;
           return true;
@@ -342,16 +393,17 @@ function createExtendedViewModel<T extends object>(
 
 ### Propósito del Extended ViewModel
 
-**Problema:** Los bindings dentro del template necesitan acceder tanto al item actual como al ViewModel parent.
+**Problema:** Los bindings dentro del template necesitan acceder tanto al item actual como al ViewModel parent, y opcionalmente al índice del loop.
 
 ```html
-<div for-each="todo of todos">
-  <span bind-value="todo.title"></span>      <!-- item scope -->
-  <button click="deleteTodo">Delete</button>  <!-- parent scope -->
+<div for-each="(todo, i) of todos">
+  <span bind-value="i"></span>                 <!-- index scope -->
+  <span bind-value="todo.title"></span>        <!-- item scope -->
+  <button click="deleteTodo">Delete</button>   <!-- parent scope -->
 </div>
 ```
 
-**Solución:** Un Proxy que combina ambos scopes.
+**Solución:** Un Proxy que combina todos los scopes.
 
 ### Diagrama de Scopes
 
@@ -369,14 +421,20 @@ function createExtendedViewModel<T extends object>(
 │    current: { id: 1, title: "Task 1", done: false }        │
 │  }                                                           │
 │                                                              │
+│  indexRef = {                                                │
+│    current: 0                                               │
+│  }                                                           │
+│                                                              │
 │  extendedViewModel = Proxy {                                │
 │    get(target, prop):                                       │
+│      ├─ prop === "i"              → indexRef.current         │
 │      ├─ prop === "todo"           → itemRef.current         │
 │      ├─ prop.startsWith("todo.")  → itemRef.current[...]    │
 │      └─ else                      → parentViewModel[prop]   │
 │  }                                                           │
 │                                                              │
 │  Accesos:                                                   │
+│    extendedVM.i              → 0                            │
 │    extendedVM.todo           → { id: 1, title: "Task 1" }  │
 │    extendedVM.todo.title     → "Task 1"                     │
 │    extendedVM.deleteTodo     → function() { ... }           │
@@ -451,10 +509,13 @@ function createNewElement<T extends object>(
   const element = binding.template.cloneNode(true) as HTMLElement;
 
   const itemRef = { current: item };
+  const indexRef = { current: index };
   const extendedViewModel = createExtendedViewModel(
     viewModel,
     binding.itemName,
     itemRef,
+    binding.indexName,
+    indexRef,
   );
 
   const render = setupBindingsForElement(element, extendedViewModel);
@@ -463,6 +524,7 @@ function createNewElement<T extends object>(
     element,
     viewModel: extendedViewModel,
     itemRef,
+    indexRef,
     render,
   });
 
@@ -485,11 +547,12 @@ createNewElement(binding, viewModel, item, index)
     ├─► 1. CLONE TEMPLATE
     │      element = binding.template.cloneNode(true)
     │
-    ├─► 2. CREATE ITEM REF
+    ├─► 2. CREATE REFS
     │      itemRef = { current: item }
+    │      indexRef = { current: index }
     │
     ├─► 3. CREATE EXTENDED VIEW MODEL
-    │      extendedViewModel = Proxy(parent + item)
+    │      extendedViewModel = Proxy(parent + item + index)
     │
     ├─► 4. SETUP BINDINGS FOR ELEMENT
     │      render = setupBindingsForElement(element, extendedVM)
@@ -673,6 +736,7 @@ function updateExistingElements(
     const rendered = binding.renderedElements[i];
 
     rendered.itemRef.current = item;
+    rendered.indexRef.current = i;
     rendered.render();
   }
 }
@@ -758,7 +822,7 @@ DOM final:
   <div>Task 3</div>
 ```
 
-**Nota:** PelelaJS **no** usa keyed rendering como React. Reutiliza elementos por posición, no por identidad.
+**Nota:** Reconciliación por posición (sin `key`). Ver Limitaciones para detalle.
 
 ## Fase 6: Bindings Anidados dentro de for-each
 
@@ -1207,7 +1271,7 @@ describe("for-each binding", () => {
 
 ### 1. No Keyed Rendering
 
-PelelaJS reutiliza elementos por posición, no por key:
+PelelaJS reutiliza elementos por posición (sin `key`). Esta es una decisión de diseño actual para mantener el runtime simple y didáctico. Para los casos de uso actuales alcanza; si se necesita identidad estable en reordenamientos, se evaluará incorporar `key`:
 
 ```typescript
 items = [
@@ -1283,4 +1347,3 @@ Es la piedra angular para construir listas dinámicas en PelelaJS.
 - [bind-value](./03-bind-value.md)
 - [Propiedades Anidadas](../05-nested-properties/01-nested-properties.md)
 - [ReactiveProxy](../03-reactivity/01-reactive-proxy.md)
-

--- a/examples/for-each/src/app.pelela
+++ b/examples/for-each/src/app.pelela
@@ -22,8 +22,10 @@
   <h2>Lista de Ítems</h2>
   
   <ul>
-    <div for-each="item of items">
+    <div for-each="(item, index) of items">
       <li if="item.visible">
+        <span bind-value="index"></span>
+        <span> - </span>
         <span bind-value="item.text"></span>
       </li>
     </div>

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -5,6 +5,7 @@ import {
   PropertyValidationError,
 } from '../errors/index'
 import { renderForEachBindings, setupForEachBindings } from './bindForEach'
+import { setupBindings } from './setupBindings'
 
 describe('bindForEach', () => {
   let container: HTMLElement
@@ -27,6 +28,40 @@ describe('bindForEach', () => {
 
       expect(bindings).toHaveLength(1)
       expect(bindings[0].itemName).toBe('user')
+      expect(bindings[0].collectionName).toBe('users')
+    })
+
+    it('should parse for-each expression with index correctly', () => {
+      container.innerHTML = `
+        <div for-each="(user, index) of users">
+          <span bind-value="index"></span>
+          <span bind-value="user.name"></span>
+        </div>
+      `
+
+      const viewModel = { users: [] }
+      const bindings = setupForEachBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].itemName).toBe('user')
+      expect(bindings[0].indexName).toBe('index')
+      expect(bindings[0].collectionName).toBe('users')
+    })
+
+    it('should parse for-each expression with custom index name', () => {
+      container.innerHTML = `
+        <div for-each="(user, i) of users">
+          <span bind-value="i"></span>
+          <span bind-value="user.name"></span>
+        </div>
+      `
+
+      const viewModel = { users: [] }
+      const bindings = setupForEachBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].itemName).toBe('user')
+      expect(bindings[0].indexName).toBe('i')
       expect(bindings[0].collectionName).toBe('users')
     })
 
@@ -71,6 +106,56 @@ describe('bindForEach', () => {
     it('should throw InvalidBindingSyntaxError for invalid expression', () => {
       container.innerHTML = '<div for-each="invalid"></div>'
       const viewModel = { invalid: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should throw InvalidBindingSyntaxError for invalid indexed expression', () => {
+      container.innerHTML = '<div for-each="(item index) of items"></div>'
+      const viewModel = { items: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should throw InvalidBindingSyntaxError when item and index names are equal', () => {
+      container.innerHTML = '<div for-each="(item, item) of items"></div>'
+      const viewModel = { items: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should create placeholder comment with index syntax', () => {
+      container.innerHTML = `
+        <div for-each="(item, idx) of items"></div>
+      `
+
+      const viewModel = { items: [] }
+      setupForEachBindings(container, viewModel)
+
+      const comment = Array.from(container.childNodes).find(
+        (node) => node.nodeType === Node.COMMENT_NODE,
+      )
+      expect(comment?.textContent).toContain('for-each: (item, idx) of items')
+    })
+
+    it('should throw InvalidBindingSyntaxError for malformed index expression with trailing comma', () => {
+      container.innerHTML = '<div for-each="(item,) of items"></div>'
+      const viewModel = { items: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should throw InvalidBindingSyntaxError for unclosed parenthesis', () => {
+      container.innerHTML = '<div for-each="(item, index of items"></div>'
+      const viewModel = { items: [] }
 
       expect(() => {
         setupForEachBindings(container, viewModel)
@@ -268,6 +353,134 @@ describe('bindForEach', () => {
       expect(span?.textContent).toBe('Updated')
     })
 
+    it('should render zero-based index with indexed for-each syntax', () => {
+      container.innerHTML = `
+        <div for-each="(item, idx) of items">
+          <span bind-value="idx"></span>
+          <span bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [{ text: 'First' }, { text: 'Second' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const divs = container.querySelectorAll('div')
+      expect(divs).toHaveLength(2)
+      expect(divs[0].querySelectorAll('span')[0].textContent).toBe('0')
+      expect(divs[0].querySelectorAll('span')[1].textContent).toBe('First')
+      expect(divs[1].querySelectorAll('span')[0].textContent).toBe('1')
+      expect(divs[1].querySelectorAll('span')[1].textContent).toBe('Second')
+    })
+
+    it('should recalculate indexes after unshift', () => {
+      container.innerHTML = `
+        <div for-each="(item, idx) of items">
+          <span bind-value="idx"></span>
+          <span bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [{ text: 'A' }, { text: 'B' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      viewModel.items.unshift({ text: 'Z' })
+      renderForEachBindings(bindings, viewModel)
+
+      const divs = container.querySelectorAll('div')
+      expect(divs).toHaveLength(3)
+      expect(divs[0].querySelectorAll('span')[0].textContent).toBe('0')
+      expect(divs[0].querySelectorAll('span')[1].textContent).toBe('Z')
+      expect(divs[1].querySelectorAll('span')[0].textContent).toBe('1')
+      expect(divs[1].querySelectorAll('span')[1].textContent).toBe('A')
+      expect(divs[2].querySelectorAll('span')[0].textContent).toBe('2')
+      expect(divs[2].querySelectorAll('span')[1].textContent).toBe('B')
+    })
+
+    it('should recalculate indexes after sort', () => {
+      container.innerHTML = `
+        <div for-each="(item, idx) of items">
+          <span bind-value="idx"></span>
+          <span bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [{ text: 'B' }, { text: 'A' }, { text: 'C' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      viewModel.items.sort((a, b) => a.text.localeCompare(b.text))
+      renderForEachBindings(bindings, viewModel)
+
+      const divs = container.querySelectorAll('div')
+      expect(divs).toHaveLength(3)
+      expect(divs[0].querySelectorAll('span')[0].textContent).toBe('0')
+      expect(divs[0].querySelectorAll('span')[1].textContent).toBe('A')
+      expect(divs[1].querySelectorAll('span')[0].textContent).toBe('1')
+      expect(divs[1].querySelectorAll('span')[1].textContent).toBe('B')
+      expect(divs[2].querySelectorAll('span')[0].textContent).toBe('2')
+      expect(divs[2].querySelectorAll('span')[1].textContent).toBe('C')
+    })
+
+    it('should update index when array shrinks', () => {
+      container.innerHTML = `
+        <div for-each="(item, index) of items">
+          <span class="idx" bind-value="index"></span>
+          <span class="text" bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [{ text: 'A' }, { text: 'B' }, { text: 'C' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      viewModel.items.shift()
+      renderForEachBindings(bindings, viewModel)
+
+      const divs = container.querySelectorAll('div')
+      expect(divs).toHaveLength(2)
+      expect(divs[0].querySelector('.idx')?.textContent).toBe('0')
+      expect(divs[0].querySelector('.text')?.textContent).toBe('B')
+      expect(divs[1].querySelector('.idx')?.textContent).toBe('1')
+      expect(divs[1].querySelector('.text')?.textContent).toBe('C')
+    })
+
+    it('should assign correct indexes when array grows', () => {
+      container.innerHTML = `
+        <div for-each="(item, i) of items">
+          <span bind-value="i"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [{ text: 'A' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      viewModel.items.push({ text: 'B' }, { text: 'C' })
+      renderForEachBindings(bindings, viewModel)
+
+      const spans = container.querySelectorAll('span')
+      expect(spans[0].textContent).toBe('0')
+      expect(spans[1].textContent).toBe('1')
+      expect(spans[2].textContent).toBe('2')
+    })
+
     it('should handle list items', () => {
       container.innerHTML = `
         <ul>
@@ -429,6 +642,105 @@ describe('bindForEach', () => {
       expect(spans[2].style.display).not.toBe('none')
       expect(spans[2].textContent).toBe('Third')
       expect(spans[2].className).toBe('highlight')
+    })
+
+    it('should support index with nested bindings in repeated template', () => {
+      container.innerHTML = `
+        <div for-each="(item, index) of items">
+          <span bind-value="index"></span>
+          <span if="item.visible" bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [
+          { text: 'Visible', visible: true },
+          { text: 'Hidden', visible: false },
+        ],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const divs = container.querySelectorAll('div')
+      expect(divs).toHaveLength(2)
+      expect(divs[0].querySelectorAll('span')[0].textContent).toBe('0')
+      expect(divs[0].querySelectorAll('span')[1].textContent).toBe('Visible')
+      expect(divs[0].querySelectorAll('span')[1].style.display).not.toBe('none')
+      expect(divs[1].querySelectorAll('span')[0].textContent).toBe('1')
+      expect(divs[1].querySelectorAll('span')[1].textContent).toBe('Hidden')
+      expect(divs[1].querySelectorAll('span')[1].style.display).toBe('none')
+    })
+
+    it('should ignore writes to index and restore real index on next render', () => {
+      container.innerHTML = `
+        <div for-each="(item, index) of items">
+          <input class="idx-input" bind-value="index" />
+          <span class="idx-text" bind-value="index"></span>
+          <span class="item-text" bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        items: [{ text: 'A' }, { text: 'B' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const firstInput = container.querySelectorAll<HTMLInputElement>('.idx-input')[0]
+      expect(firstInput.value).toBe('0')
+
+      firstInput.value = '999'
+      firstInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+      renderForEachBindings(bindings, viewModel)
+
+      const idxInputs = container.querySelectorAll<HTMLInputElement>('.idx-input')
+      const idxTexts = container.querySelectorAll('.idx-text')
+      const itemTexts = container.querySelectorAll('.item-text')
+
+      expect(idxInputs[0].value).toBe('0')
+      expect(idxInputs[1].value).toBe('1')
+      expect(idxTexts[0].textContent).toBe('0')
+      expect(idxTexts[1].textContent).toBe('1')
+      expect(itemTexts[0].textContent).toBe('A')
+      expect(itemTexts[1].textContent).toBe('B')
+    })
+
+    it('should prioritize for-each index scope over parent property with same name', () => {
+      container.innerHTML = `
+        <span id="outside" bind-value="i"></span>
+        <div for-each="(item, i) of items">
+          <span class="inside-index" bind-value="i"></span>
+          <span class="inside-item" bind-value="item.text"></span>
+        </div>
+      `
+
+      const viewModel = {
+        i: 999,
+        items: [{ text: 'A' }, { text: 'B' }],
+      }
+
+      const render = setupBindings(container, viewModel)
+
+      expect(container.querySelector('#outside')?.textContent).toBe('999')
+      expect(container.querySelectorAll('.inside-index')[0].textContent).toBe('0')
+      expect(container.querySelectorAll('.inside-index')[1].textContent).toBe('1')
+
+      viewModel.items.unshift({ text: 'Z' })
+      render('items')
+
+      const insideIndexes = container.querySelectorAll('.inside-index')
+      const insideItems = container.querySelectorAll('.inside-item')
+
+      expect(container.querySelector('#outside')?.textContent).toBe('999')
+      expect(insideIndexes[0].textContent).toBe('0')
+      expect(insideIndexes[1].textContent).toBe('1')
+      expect(insideIndexes[2].textContent).toBe('2')
+      expect(insideItems[0].textContent).toBe('Z')
+      expect(insideItems[1].textContent).toBe('A')
+      expect(insideItems[2].textContent).toBe('B')
     })
 
     it('should work with select and option elements', () => {

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -130,6 +130,33 @@ describe('bindForEach', () => {
       }).toThrow(InvalidBindingSyntaxError)
     })
 
+    it('should throw InvalidBindingSyntaxError when item and collection names are equal', () => {
+      container.innerHTML = '<div for-each="items of items"></div>'
+      const viewModel = { items: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should throw InvalidBindingSyntaxError when indexed item and collection names are equal', () => {
+      container.innerHTML = '<div for-each="(items, i) of items"></div>'
+      const viewModel = { items: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should throw InvalidBindingSyntaxError when index and collection names are equal', () => {
+      container.innerHTML = '<div for-each="(item, items) of items"></div>'
+      const viewModel = { items: [] }
+
+      expect(() => {
+        setupForEachBindings(container, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
     it('should create placeholder comment with index syntax', () => {
       container.innerHTML = `
         <div for-each="(item, idx) of items"></div>

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -255,6 +255,14 @@ function setupSingleForEachBinding<T extends object>(
     )
   }
 
+  if (itemName === collectionName || indexName === collectionName) {
+    throw new InvalidBindingSyntaxError(
+      'for-each',
+      expression,
+      'item, index and collection names must be different',
+    )
+  }
+
   assertViewModelProperty(viewModel, collectionName, 'for-each', element)
 
   const collection = viewModel[collectionName]

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -11,15 +11,30 @@ import { renderStyleBindings, setupStyleBindings } from './bindStyle'
 import { renderValueBindings, setupValueBindings } from './bindValue'
 import type { ForEachBinding, ViewModel } from './types'
 
-function parseForEachExpression(expression: string): {
+type ParsedForEachExpression = {
   itemName: string
+  indexName?: string
   collectionName: string
-} | null {
-  const match = expression.trim().match(/^(\w+)\s+of\s+(\w+)$/)
-  if (!match) return null
+}
+
+function parseForEachExpression(expression: string): ParsedForEachExpression | null {
+  const normalizedExpression = expression.trim()
+
+  const indexedMatch = normalizedExpression.match(/^\(\s*(\w+)\s*,\s*(\w+)\s*\)\s+of\s+(\w+)$/)
+  if (indexedMatch) {
+    return {
+      itemName: indexedMatch[1],
+      indexName: indexedMatch[2],
+      collectionName: indexedMatch[3],
+    }
+  }
+
+  const defaultMatch = normalizedExpression.match(/^(\w+)\s+of\s+(\w+)$/)
+  if (!defaultMatch) return null
+
   return {
-    itemName: match[1],
-    collectionName: match[2],
+    itemName: defaultMatch[1],
+    collectionName: defaultMatch[2],
   }
 }
 
@@ -27,11 +42,14 @@ function createExtendedViewModel<T extends object>(
   parentViewModel: ViewModel<T>,
   itemName: string,
   itemRef: { current: any },
+  indexName?: string,
+  indexRef?: { current: number },
 ): ViewModel {
   return new Proxy(
     {},
     {
       has(_target, prop) {
+        if (indexName && prop === indexName) return true
         if (prop === itemName) return true
         if (typeof prop === 'string' && prop.startsWith(`${itemName}.`)) {
           return true
@@ -39,6 +57,12 @@ function createExtendedViewModel<T extends object>(
         return prop in parentViewModel
       },
       get(_target, prop) {
+        if (indexName && prop === indexName) {
+          if (!indexRef) {
+            throw new Error('[pelela] Internal error: missing indexRef for indexed for-each')
+          }
+          return indexRef.current
+        }
         if (prop === itemName) {
           return itemRef.current
         }
@@ -49,6 +73,9 @@ function createExtendedViewModel<T extends object>(
         return parentViewModel[prop as string]
       },
       set(_target, prop, value) {
+        if (indexName && prop === indexName) {
+          return true
+        }
         if (prop === itemName) {
           itemRef.current = value
           return true
@@ -211,10 +238,22 @@ function setupSingleForEachBinding<T extends object>(
 
   const parsed = parseForEachExpression(expression)
   if (!parsed) {
-    throw new InvalidBindingSyntaxError('for-each', expression, 'item of collection')
+    throw new InvalidBindingSyntaxError(
+      'for-each',
+      expression,
+      'item of collection or (item, index) of collection',
+    )
   }
 
-  const { itemName, collectionName } = parsed
+  const { itemName, indexName, collectionName } = parsed
+
+  if (indexName && itemName === indexName) {
+    throw new InvalidBindingSyntaxError(
+      'for-each',
+      expression,
+      'item and index names must be different',
+    )
+  }
 
   assertViewModelProperty(viewModel, collectionName, 'for-each', element)
 
@@ -232,8 +271,12 @@ function setupSingleForEachBinding<T extends object>(
   const template = element.cloneNode(true) as HTMLElement
   template.removeAttribute('for-each')
 
+  const displayExpression = indexName
+    ? `(${itemName}, ${indexName}) of ${collectionName}`
+    : `${itemName} of ${collectionName}`
+
   console.log(
-    `[pelela] for-each setup: ${itemName} of ${collectionName}, element:`,
+    `[pelela] for-each setup: ${displayExpression}, element:`,
     element.tagName,
     'parent:',
     element.parentNode?.nodeName,
@@ -243,13 +286,14 @@ function setupSingleForEachBinding<T extends object>(
     throw new InvalidDOMStructureError('for-each', 'element has no parent node')
   }
 
-  const placeholder = document.createComment(`for-each: ${itemName} of ${collectionName}`)
+  const placeholder = document.createComment(`for-each: ${displayExpression}`)
   element.parentNode.insertBefore(placeholder, element)
   element.remove()
 
   return {
     collectionName,
     itemName,
+    indexName,
     template,
     placeholder,
     renderedElements: [],
@@ -290,7 +334,14 @@ function createNewElement<T extends object>(
   )
 
   const itemRef = { current: item }
-  const extendedViewModel = createExtendedViewModel(viewModel, binding.itemName, itemRef)
+  const indexRef = { current: index }
+  const extendedViewModel = createExtendedViewModel(
+    viewModel,
+    binding.itemName,
+    itemRef,
+    binding.indexName,
+    indexRef,
+  )
 
   const render = setupBindingsForElement(element, extendedViewModel)
 
@@ -298,6 +349,7 @@ function createNewElement<T extends object>(
     element,
     viewModel: extendedViewModel,
     itemRef,
+    indexRef,
     render,
   })
 
@@ -350,6 +402,7 @@ function updateExistingElements(binding: ForEachBinding, collection: any[]): voi
     const rendered = binding.renderedElements[i]
 
     rendered.itemRef.current = item
+    rendered.indexRef.current = i
     rendered.render()
   }
 }

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -28,12 +28,14 @@ export type StyleBinding = {
 export type ForEachBinding = {
   collectionName: string
   itemName: string
+  indexName?: string
   template: HTMLElement
   placeholder: Comment
   renderedElements: {
     element: HTMLElement
     viewModel: ViewModel
     itemRef: { current: any }
+    indexRef: { current: number }
     render: () => void
   }[]
   previousLength: number

--- a/tools/pelela-vscode/html-custom-data.json
+++ b/tools/pelela-vscode/html-custom-data.json
@@ -45,7 +45,7 @@
     },
     {
       "name": "for-each",
-      "description": "Pelela: Iterates over a collection from the ViewModel (syntax: item of collection)",
+      "description": "Pelela: Iterates over a collection from the ViewModel (syntax: item of collection or (item, index) of collection)",
       "valueSet": "v"
     }
   ]

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -17,17 +17,46 @@ function getAttributeValueMatch(textBeforeCursor) {
   return attrValueMatch ? attrValueMatch[1] : null
 }
 
+function parseForEachValue(forEachValue) {
+  const indexedExprMatch = /^\s*\(\s*(\w+)\s*,\s*(\w+)\s*\)\s+of\s+(\w+)\s*$/.exec(forEachValue)
+  if (indexedExprMatch) {
+    return {
+      itemName: indexedExprMatch[1],
+      indexName: indexedExprMatch[2],
+      collectionName: indexedExprMatch[3],
+    }
+  }
+
+  const basicExprMatch = /^\s*(\w+)\s+of\s+(\w+)\s*$/.exec(forEachValue)
+  if (basicExprMatch) {
+    return {
+      itemName: basicExprMatch[1],
+      collectionName: basicExprMatch[2],
+    }
+  }
+
+  return null
+}
+
 function findForEachInElement(document, currentLine) {
   const forEachResults = []
 
   for (let i = currentLine; i >= 0; i--) {
     const lineText = document.lineAt(i).text
+    const forEachExpression = parseForEachExpression(lineText)
+    if (forEachExpression) {
+      const attrStart = lineText.indexOf('for-each=')
+      const itemPos = lineText.indexOf(forEachExpression.itemName, attrStart)
+      const indexPos = forEachExpression.indexName
+        ? lineText.indexOf(forEachExpression.indexName, attrStart)
+        : undefined
 
-    const forEachMatch = /for-each=["'](\w+)\s+of\s+\w+["']/.exec(lineText)
-    if (forEachMatch) {
-      const itemName = forEachMatch[1]
-      const itemPos = lineText.indexOf(itemName, lineText.indexOf('for-each='))
-      forEachResults.push({ itemName, line: i, itemPos })
+      forEachResults.push({
+        ...forEachExpression,
+        line: i,
+        itemPos,
+        indexPos,
+      })
     }
   }
 
@@ -35,14 +64,12 @@ function findForEachInElement(document, currentLine) {
 }
 
 function parseForEachExpression(forEachLine) {
-  const forEachExprMatch = /for-each=["'](\w+)\s+of\s+(\w+)["']/.exec(forEachLine)
-  if (forEachExprMatch) {
-    return {
-      itemName: forEachExprMatch[1],
-      collectionName: forEachExprMatch[2],
-    }
+  const forEachAttrMatch = /for-each=["']([^"']+)["']/.exec(forEachLine)
+  if (!forEachAttrMatch) {
+    return null
   }
-  return null
+
+  return parseForEachValue(forEachAttrMatch[1])
 }
 
 function parsePropertyPath(valueBeforeCursor) {

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -45,11 +45,26 @@ function findForEachInElement(document, currentLine) {
     const lineText = document.lineAt(i).text
     const forEachExpression = parseForEachExpression(lineText)
     if (forEachExpression) {
-      const attrStart = lineText.indexOf('for-each=')
-      const itemPos = lineText.indexOf(forEachExpression.itemName, attrStart)
-      const indexPos = forEachExpression.indexName
-        ? lineText.indexOf(forEachExpression.indexName, attrStart)
-        : undefined
+      const attrMatch = /for-each=(["'])([^"']+)\1/.exec(lineText)
+      if (!attrMatch) {
+        continue
+      }
+
+      const attrText = attrMatch[0]
+      const attrValue = attrMatch[2]
+      const valueStart = attrMatch.index + attrText.indexOf(attrValue)
+
+      const itemOffset = attrValue.indexOf(forEachExpression.itemName)
+      if (itemOffset < 0) {
+        continue
+      }
+      const itemPos = valueStart + itemOffset
+
+      let indexPos
+      if (forEachExpression.indexName) {
+        const indexOffset = attrValue.indexOf(forEachExpression.indexName)
+        indexPos = indexOffset >= 0 ? valueStart + indexOffset : undefined
+      }
 
       forEachResults.push({
         ...forEachExpression,

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -64,7 +64,9 @@ function getForEachAliasPositions(attrValue, hasIndexAlias) {
 
 function findForEachHostTag(document, forEachLine) {
   const forEachLineText = document.lineAt(forEachLine).text ?? ''
-  const inlineHostMatch = /<\s*([a-zA-Z][\w-]*)\b[^>]*\bfor-each\s*=/.exec(forEachLineText)
+  const inlineHostMatch = /<\s*([a-zA-Z][\w-]*)\b[^>]*\bfor-each\s*=[^>]*(?:>|$)/.exec(
+    forEachLineText
+  )
   if (inlineHostMatch) {
     return {
       line: forEachLine,
@@ -95,7 +97,10 @@ function findForEachScopeEndBeforeCursor(
   tagName
 ) {
   const tagRegex = new RegExp(`<\\/?\\s*${tagName}\\b[^>]*>`, 'g')
-  let openDepth = 0
+  const hostLineText = document.lineAt(hostStartLine).text ?? ''
+  const hostOpenTagMatch = new RegExp(`<\\s*${tagName}\\b[^>]*>`).exec(hostLineText)
+  // Host loop tag is always open by definition at this point.
+  let openDepth = 1
 
   for (let lineIndex = hostStartLine; lineIndex <= currentLine; lineIndex++) {
     const fullLineText = document.lineAt(lineIndex).text ?? ''
@@ -108,6 +113,17 @@ function findForEachScopeEndBeforeCursor(
       const tagText = tagMatch[0]
       const isClosingTag = /^<\s*\//.test(tagText)
       const isSelfClosingTag = /\/\s*>$/.test(tagText)
+
+      // Avoid double-counting the host opening tag when it is fully present in hostStartLine.
+      if (
+        lineIndex === hostStartLine &&
+        hostOpenTagMatch &&
+        !isClosingTag &&
+        !isSelfClosingTag &&
+        tagMatch.index === hostOpenTagMatch.index
+      ) {
+        continue
+      }
 
       if (isClosingTag) {
         openDepth -= 1

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -38,6 +38,30 @@ function parseForEachValue(forEachValue) {
   return null
 }
 
+function getForEachAliasPositions(attrValue, hasIndexAlias) {
+  if (hasIndexAlias) {
+    const indexedMatch = /^(\s*\(\s*)(\w+)(\s*,\s*)(\w+)(\s*\)\s+of\s+)(\w+)(\s*)$/.exec(attrValue)
+    if (!indexedMatch) {
+      return null
+    }
+
+    return {
+      itemPos: indexedMatch[1].length,
+      indexPos: indexedMatch[1].length + indexedMatch[2].length + indexedMatch[3].length,
+    }
+  }
+
+  const basicMatch = /^(\s*)(\w+)(\s+of\s+)(\w+)(\s*)$/.exec(attrValue)
+  if (!basicMatch) {
+    return null
+  }
+
+  return {
+    itemPos: basicMatch[1].length,
+    indexPos: undefined,
+  }
+}
+
 function findForEachInElement(document, currentLine) {
   const forEachResults = []
 
@@ -54,17 +78,16 @@ function findForEachInElement(document, currentLine) {
       const attrValue = attrMatch[2]
       const valueStart = attrMatch.index + attrText.indexOf(attrValue)
 
-      const itemOffset = attrValue.indexOf(forEachExpression.itemName)
-      if (itemOffset < 0) {
+      const aliasPositions = getForEachAliasPositions(attrValue, !!forEachExpression.indexName)
+      if (!aliasPositions) {
         continue
       }
-      const itemPos = valueStart + itemOffset
 
-      let indexPos
-      if (forEachExpression.indexName) {
-        const indexOffset = attrValue.indexOf(forEachExpression.indexName)
-        indexPos = indexOffset >= 0 ? valueStart + indexOffset : undefined
-      }
+      const itemPos = valueStart + aliasPositions.itemPos
+      const indexPos =
+        typeof aliasPositions.indexPos === 'number'
+          ? valueStart + aliasPositions.indexPos
+          : undefined
 
       forEachResults.push({
         ...forEachExpression,

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -62,14 +62,34 @@ function getForEachAliasPositions(attrValue, hasIndexAlias) {
   }
 }
 
-function getForEachTagName(lineText) {
-  const tagMatch = /<\s*([a-zA-Z][\w-]*)\b[^>]*\bfor-each\s*=/.exec(lineText)
-  return tagMatch ? tagMatch[1] : null
+function findForEachHostTag(document, forEachLine) {
+  const forEachLineText = document.lineAt(forEachLine).text ?? ''
+  const inlineHostMatch = /<\s*([a-zA-Z][\w-]*)\b[^>]*\bfor-each\s*=/.exec(forEachLineText)
+  if (inlineHostMatch) {
+    return {
+      line: forEachLine,
+      tagName: inlineHostMatch[1],
+    }
+  }
+
+  for (let lineIndex = forEachLine; lineIndex >= 0; lineIndex--) {
+    const lineText = document.lineAt(lineIndex).text ?? ''
+    const tagMatches = [...lineText.matchAll(/<\s*([a-zA-Z][\w-]*)\b[^>]*(?:>|$)/g)]
+    if (tagMatches.length > 0) {
+      const lastTagMatch = tagMatches[tagMatches.length - 1]
+      return {
+        line: lineIndex,
+        tagName: lastTagMatch[1],
+      }
+    }
+  }
+
+  return null
 }
 
 function findForEachScopeEndBeforeCursor(
   document,
-  forEachLine,
+  hostStartLine,
   currentLine,
   currentCharacter,
   tagName
@@ -77,7 +97,7 @@ function findForEachScopeEndBeforeCursor(
   const tagRegex = new RegExp(`<\\/?\\s*${tagName}\\b[^>]*>`, 'g')
   let openDepth = 0
 
-  for (let lineIndex = forEachLine; lineIndex <= currentLine; lineIndex++) {
+  for (let lineIndex = hostStartLine; lineIndex <= currentLine; lineIndex++) {
     const fullLineText = document.lineAt(lineIndex).text ?? ''
     const lineText =
       lineIndex === currentLine && typeof currentCharacter === 'number'
@@ -106,15 +126,15 @@ function findForEachScopeEndBeforeCursor(
   return null
 }
 
-function isWithinForEachScope(document, forEachLine, currentLine, currentCharacter, tagName) {
-  if (currentLine === forEachLine) {
+function isWithinForEachScope(document, hostStartLine, currentLine, currentCharacter, tagName) {
+  if (currentLine === hostStartLine) {
     return true
   }
 
   // The cursor is inside the loop scope only if the host tag has not closed yet.
   const scopeEnd = findForEachScopeEndBeforeCursor(
     document,
-    forEachLine,
+    hostStartLine,
     currentLine,
     currentCharacter,
     tagName
@@ -134,12 +154,20 @@ function findForEachInElement(document, currentLine, currentCharacter) {
         continue
       }
 
-      const forEachTagName = getForEachTagName(lineText)
-      if (!forEachTagName) {
+      const hostTag = findForEachHostTag(document, i)
+      if (!hostTag) {
         continue
       }
 
-      if (!isWithinForEachScope(document, i, currentLine, currentCharacter, forEachTagName)) {
+      if (
+        !isWithinForEachScope(
+          document,
+          hostTag.line,
+          currentLine,
+          currentCharacter,
+          hostTag.tagName
+        )
+      ) {
         continue
       }
 

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -1,6 +1,6 @@
 function getCurrentAttributeName(lineText, positionCharacter) {
   const textUpToCursor = lineText.slice(0, positionCharacter)
-  const match = /(\b[\w-]+)\s*=\s*"[^"]*$/.exec(textUpToCursor)
+  const match = /(\b[\w-]+)\s*=\s*["'][^"']*$/.exec(textUpToCursor)
   return match ? match[1] : null
 }
 
@@ -13,7 +13,7 @@ function isStartingTag(textBeforeCursor) {
 }
 
 function getAttributeValueMatch(textBeforeCursor) {
-  const attrValueMatch = /=\s*"([^"]*)$/.exec(textBeforeCursor)
+  const attrValueMatch = /=\s*["']([^"']*)$/.exec(textBeforeCursor)
   return attrValueMatch ? attrValueMatch[1] : null
 }
 
@@ -70,6 +70,7 @@ function findForEachHostTag(document, forEachLine) {
   if (inlineHostMatch) {
     return {
       line: forEachLine,
+      character: inlineHostMatch.index,
       tagName: inlineHostMatch[1],
     }
   }
@@ -81,6 +82,7 @@ function findForEachHostTag(document, forEachLine) {
       const lastTagMatch = tagMatches[tagMatches.length - 1]
       return {
         line: lineIndex,
+        character: lastTagMatch.index,
         tagName: lastTagMatch[1],
       }
     }
@@ -92,57 +94,62 @@ function findForEachHostTag(document, forEachLine) {
 function findForEachScopeEndBeforeCursor(
   document,
   hostStartLine,
+  hostStartCharacter,
   currentLine,
   currentCharacter,
   tagName
 ) {
-  const tagRegex = new RegExp(`<\\/?\\s*${tagName}\\b[^>]*>`, 'g')
-  const hostLineText = document.lineAt(hostStartLine).text ?? ''
-  const hostOpenTagMatch = new RegExp(`<\\s*${tagName}\\b[^>]*>`).exec(hostLineText)
-  // Host loop tag is always open by definition at this point.
-  let openDepth = 1
-
+  const textLines = []
   for (let lineIndex = hostStartLine; lineIndex <= currentLine; lineIndex++) {
     const fullLineText = document.lineAt(lineIndex).text ?? ''
-    const lineText =
-      lineIndex === currentLine && typeof currentCharacter === 'number'
-        ? fullLineText.slice(0, currentCharacter)
-        : fullLineText
+    let lineText = fullLineText
+    if (lineIndex === hostStartLine) {
+      lineText = lineText.slice(hostStartCharacter)
+    }
+    if (lineIndex === currentLine && typeof currentCharacter === 'number') {
+      lineText = lineText.slice(0, currentCharacter)
+    }
+    textLines.push(lineText)
+  }
 
-    for (const tagMatch of lineText.matchAll(tagRegex)) {
-      const tagText = tagMatch[0]
-      const isClosingTag = /^<\s*\//.test(tagText)
-      const isSelfClosingTag = /\/\s*>$/.test(tagText)
+  const scopeText = textLines.join('\n')
+  const tagRegex = new RegExp(`<\\/?\\s*${tagName}\\b[^>]*>`, 'g')
+  // Host loop tag is always open by definition at this point.
+  let openDepth = 1
+  let hostOpeningSkipped = false
 
-      // Avoid double-counting the host opening tag when it is fully present in hostStartLine.
-      if (
-        lineIndex === hostStartLine &&
-        hostOpenTagMatch &&
-        !isClosingTag &&
-        !isSelfClosingTag &&
-        tagMatch.index === hostOpenTagMatch.index
-      ) {
-        continue
+  for (const tagMatch of scopeText.matchAll(tagRegex)) {
+    const tagText = tagMatch[0]
+    const isClosingTag = /^<\s*\//.test(tagText)
+    const isSelfClosingTag = /\/\s*>$/.test(tagText)
+
+    // Skip host opening (first non-closing/non-self-closing match) to avoid double count.
+    if (!hostOpeningSkipped && !isClosingTag && !isSelfClosingTag) {
+      hostOpeningSkipped = true
+      continue
+    }
+
+    if (isClosingTag) {
+      openDepth -= 1
+      if (openDepth <= 0) {
+        return { offset: tagMatch.index }
       }
-
-      if (isClosingTag) {
-        openDepth -= 1
-        if (openDepth <= 0) {
-          return {
-            line: lineIndex,
-            character: tagMatch.index,
-          }
-        }
-      } else if (!isSelfClosingTag) {
-        openDepth += 1
-      }
+    } else if (!isSelfClosingTag) {
+      openDepth += 1
     }
   }
 
   return null
 }
 
-function isWithinForEachScope(document, hostStartLine, currentLine, currentCharacter, tagName) {
+function isWithinForEachScope(
+  document,
+  hostStartLine,
+  hostStartCharacter,
+  currentLine,
+  currentCharacter,
+  tagName
+) {
   if (currentLine === hostStartLine) {
     return true
   }
@@ -151,6 +158,7 @@ function isWithinForEachScope(document, hostStartLine, currentLine, currentChara
   const scopeEnd = findForEachScopeEndBeforeCursor(
     document,
     hostStartLine,
+    hostStartCharacter,
     currentLine,
     currentCharacter,
     tagName
@@ -165,7 +173,7 @@ function findForEachInElement(document, currentLine, currentCharacter) {
     const lineText = document.lineAt(i).text
     const forEachExpression = parseForEachExpression(lineText)
     if (forEachExpression) {
-      const attrMatch = /for-each=(["'])([^"']+)\1/.exec(lineText)
+      const attrMatch = /for-each\s*=\s*(["'])([^"']+)\1/.exec(lineText)
       if (!attrMatch) {
         continue
       }
@@ -179,6 +187,7 @@ function findForEachInElement(document, currentLine, currentCharacter) {
         !isWithinForEachScope(
           document,
           hostTag.line,
+          hostTag.character,
           currentLine,
           currentCharacter,
           hostTag.tagName
@@ -215,12 +224,12 @@ function findForEachInElement(document, currentLine, currentCharacter) {
 }
 
 function parseForEachExpression(forEachLine) {
-  const forEachAttrMatch = /for-each=["']([^"']+)["']/.exec(forEachLine)
+  const forEachAttrMatch = /for-each\s*=\s*(["'])([^"']+)\1/.exec(forEachLine)
   if (!forEachAttrMatch) {
     return null
   }
 
-  return parseForEachValue(forEachAttrMatch[1])
+  return parseForEachValue(forEachAttrMatch[2])
 }
 
 function parsePropertyPath(valueBeforeCursor) {

--- a/tools/pelela-vscode/src/parsers/documentParser.js
+++ b/tools/pelela-vscode/src/parsers/documentParser.js
@@ -62,7 +62,67 @@ function getForEachAliasPositions(attrValue, hasIndexAlias) {
   }
 }
 
-function findForEachInElement(document, currentLine) {
+function getForEachTagName(lineText) {
+  const tagMatch = /<\s*([a-zA-Z][\w-]*)\b[^>]*\bfor-each\s*=/.exec(lineText)
+  return tagMatch ? tagMatch[1] : null
+}
+
+function findForEachScopeEndBeforeCursor(
+  document,
+  forEachLine,
+  currentLine,
+  currentCharacter,
+  tagName
+) {
+  const tagRegex = new RegExp(`<\\/?\\s*${tagName}\\b[^>]*>`, 'g')
+  let openDepth = 0
+
+  for (let lineIndex = forEachLine; lineIndex <= currentLine; lineIndex++) {
+    const fullLineText = document.lineAt(lineIndex).text ?? ''
+    const lineText =
+      lineIndex === currentLine && typeof currentCharacter === 'number'
+        ? fullLineText.slice(0, currentCharacter)
+        : fullLineText
+
+    for (const tagMatch of lineText.matchAll(tagRegex)) {
+      const tagText = tagMatch[0]
+      const isClosingTag = /^<\s*\//.test(tagText)
+      const isSelfClosingTag = /\/\s*>$/.test(tagText)
+
+      if (isClosingTag) {
+        openDepth -= 1
+        if (openDepth <= 0) {
+          return {
+            line: lineIndex,
+            character: tagMatch.index,
+          }
+        }
+      } else if (!isSelfClosingTag) {
+        openDepth += 1
+      }
+    }
+  }
+
+  return null
+}
+
+function isWithinForEachScope(document, forEachLine, currentLine, currentCharacter, tagName) {
+  if (currentLine === forEachLine) {
+    return true
+  }
+
+  // The cursor is inside the loop scope only if the host tag has not closed yet.
+  const scopeEnd = findForEachScopeEndBeforeCursor(
+    document,
+    forEachLine,
+    currentLine,
+    currentCharacter,
+    tagName
+  )
+  return scopeEnd === null
+}
+
+function findForEachInElement(document, currentLine, currentCharacter) {
   const forEachResults = []
 
   for (let i = currentLine; i >= 0; i--) {
@@ -71,6 +131,15 @@ function findForEachInElement(document, currentLine) {
     if (forEachExpression) {
       const attrMatch = /for-each=(["'])([^"']+)\1/.exec(lineText)
       if (!attrMatch) {
+        continue
+      }
+
+      const forEachTagName = getForEachTagName(lineText)
+      if (!forEachTagName) {
+        continue
+      }
+
+      if (!isWithinForEachScope(document, i, currentLine, currentCharacter, forEachTagName)) {
         continue
       }
 

--- a/tools/pelela-vscode/src/providers/completionProvider.js
+++ b/tools/pelela-vscode/src/providers/completionProvider.js
@@ -192,7 +192,7 @@ function createMethodCompletionItem(name) {
 async function provideBasicViewModelCompletions(document, position, tsFile, attributeName) {
   const items = []
   const { properties, methods } = extractViewModelMembers(tsFile)
-  const forEachInElement = findForEachInElement(document, position.line)
+  const forEachInElement = findForEachInElement(document, position.line, position.character)
 
   if (attributeName.startsWith('bind-') || attributeName === 'if' || attributeName === 'for-each') {
     const localAliases = getForEachLocalAliases(forEachInElement, attributeName)
@@ -216,7 +216,7 @@ async function provideBasicViewModelCompletions(document, position, tsFile, attr
 
 async function provideNestedPropertyCompletions(document, position, tsFile, propertyPath) {
   const items = []
-  const forEachInElement = findForEachInElement(document, position.line)
+  const forEachInElement = findForEachInElement(document, position.line, position.character)
 
   if (
     forEachInElement &&

--- a/tools/pelela-vscode/src/providers/completionProvider.js
+++ b/tools/pelela-vscode/src/providers/completionProvider.js
@@ -80,7 +80,7 @@ function addPelelaAttributeCompletions(items) {
     if: { text: 'if="${1:condicion}"', detail: 'Pelela: renderizado condicional' },
     'for-each': {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: VSCode snippet placeholder
-      text: 'for-each="${1:item} of ${2:collection}"',
+      text: 'for-each="(${1:item}, ${2:index}) of ${3:collection}"',
       detail: 'Pelela: itera sobre una colección del view model',
     },
   }
@@ -125,8 +125,13 @@ async function provideAttributeValueCompletions(
   }
 
   const valueBeforeCursor = getAttributeValueMatch(textBeforeCursor)
+
+  if (attributeName === 'for-each') {
+    return await provideForEachValueCompletions(document, position, tsFile, valueBeforeCursor ?? '')
+  }
+
   if (!valueBeforeCursor) {
-    return await provideBasicViewModelCompletions(tsFile, attributeName)
+    return await provideBasicViewModelCompletions(document, position, tsFile, attributeName)
   }
 
   const propertyPath = parsePropertyPath(valueBeforeCursor)
@@ -134,26 +139,75 @@ async function provideAttributeValueCompletions(
     return await provideNestedPropertyCompletions(document, position, tsFile, propertyPath)
   }
 
-  return await provideBasicViewModelCompletions(tsFile, attributeName)
+  return await provideBasicViewModelCompletions(document, position, tsFile, attributeName)
 }
 
-async function provideBasicViewModelCompletions(tsFile, attributeName) {
+function isForEachCollectionContext(valueBeforeCursor) {
+  // `(item, index) of users` and `item of users` are both valid.
+  // Before `of`, user is naming local aliases; after `of`, user is choosing a VM collection.
+  return /(?:^|\s)of\s+(\w*)$/.test(valueBeforeCursor)
+}
+
+async function provideForEachValueCompletions(document, position, tsFile, valueBeforeCursor) {
+  if (isForEachCollectionContext(valueBeforeCursor)) {
+    return await provideBasicViewModelCompletions(document, position, tsFile, 'for-each')
+  }
+  // In the alias section of `for-each`, users are declaring names (item/index),
+  // so we intentionally avoid ViewModel suggestions there.
+  return []
+}
+
+function getForEachLocalAliases(forEachInElement, attributeName) {
+  if (attributeName === 'for-each' || !forEachInElement) {
+    return []
+  }
+
+  const aliases = [forEachInElement.itemName]
+
+  if (forEachInElement.indexName) {
+    aliases.push(forEachInElement.indexName)
+  }
+
+  return aliases
+}
+
+function buildCompletionCandidateNames(properties, localAliases) {
+  return [...new Set([...localAliases, ...properties])]
+}
+
+function createFieldCompletionItem(name, isLocalAlias) {
+  const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Field)
+  item.detail = isLocalAlias ? 'Pelela for-each local variable' : 'Pelela ViewModel property'
+  item.sortText = `!0_${name}`
+  return item
+}
+
+function createMethodCompletionItem(name) {
+  const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Method)
+  item.detail = 'Pelela ViewModel method'
+  item.sortText = `!0_${name}`
+  return item
+}
+
+async function provideBasicViewModelCompletions(document, position, tsFile, attributeName) {
   const items = []
   const { properties, methods } = extractViewModelMembers(tsFile)
+  const forEachInElement = findForEachInElement(document, position.line)
 
   if (attributeName.startsWith('bind-') || attributeName === 'if' || attributeName === 'for-each') {
-    for (const name of properties) {
-      const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Field)
-      item.detail = 'Pelela ViewModel property'
-      item.sortText = `!0_${name}`
-      items.push(item)
+    const localAliases = getForEachLocalAliases(forEachInElement, attributeName)
+    const candidateNames = buildCompletionCandidateNames(properties, localAliases)
+    const localAliasSet = new Set(localAliases)
+
+    for (const name of candidateNames) {
+      const isLocalAlias = localAliasSet.has(name)
+      const completionItem = createFieldCompletionItem(name, isLocalAlias)
+      items.push(completionItem)
     }
   } else if (attributeName === 'click') {
     for (const name of methods) {
-      const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Method)
-      item.detail = 'Pelela ViewModel method'
-      item.sortText = `!0_${name}`
-      items.push(item)
+      const completionItem = createMethodCompletionItem(name)
+      items.push(completionItem)
     }
   }
 
@@ -182,6 +236,13 @@ async function provideNestedPropertyCompletions(document, position, tsFile, prop
       }
       return items
     }
+  }
+
+  const indexName = forEachInElement?.indexName
+  // `index` is a local numeric alias in for-each, not an object path from the ViewModel.
+  // Avoid offering nested completions for expressions like `index.`
+  if (typeof indexName === 'string' && propertyPath.length === 1 && propertyPath[0] === indexName) {
+    return items
   }
 
   const nestedProps = extractNestedProperties(tsFile, propertyPath)

--- a/tools/pelela-vscode/src/providers/completionProvider.js
+++ b/tools/pelela-vscode/src/providers/completionProvider.js
@@ -80,7 +80,7 @@ function addPelelaAttributeCompletions(items) {
     if: { text: 'if="${1:condicion}"', detail: 'Pelela: renderizado condicional' },
     'for-each': {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: VSCode snippet placeholder
-      text: 'for-each="(${1:item}, ${2:index}) of ${3:collection}"',
+      text: 'for-each="${1:item} of ${2:collection}"',
       detail: 'Pelela: itera sobre una colección del view model',
     },
   }

--- a/tools/pelela-vscode/src/providers/definitionProvider.js
+++ b/tools/pelela-vscode/src/providers/definitionProvider.js
@@ -9,8 +9,8 @@ const {
 } = require('../parsers/definitionFinder')
 
 // Regex patterns for attribute matching
-const BIND_ATTRIBUTE_PATTERN = /(?:bind-[a-zA-Z0-9_-]+|if|for-each)=["']([^"']+)["']/g
-const CLICK_ATTRIBUTE_PATTERN = /click=["']([^"']+)["']/g
+const BIND_ATTRIBUTE_PATTERN = /(?:bind-[a-zA-Z0-9_-]+|if|for-each)\s*=\s*(["'])([^"']+)\1/g
+const CLICK_ATTRIBUTE_PATTERN = /click\s*=\s*(["'])([^"']+)\1/g
 
 function provideDefinition(document, position, _token) {
   const line = document.lineAt(position.line)
@@ -31,13 +31,13 @@ function provideDefinition(document, position, _token) {
 }
 
 function checkViewModelDefinition(document, position, lineText) {
-  const viewModelMatch = /view-model=["']([^"']+)["']/g.exec(lineText)
+  const viewModelMatch = /view-model\s*=\s*(["'])([^"']+)\1/g.exec(lineText)
   if (
     viewModelMatch &&
-    position.character >= lineText.indexOf(viewModelMatch[1]) &&
-    position.character <= lineText.indexOf(viewModelMatch[1]) + viewModelMatch[1].length
+    position.character >= lineText.indexOf(viewModelMatch[2]) &&
+    position.character <= lineText.indexOf(viewModelMatch[2]) + viewModelMatch[2].length
   ) {
-    const className = viewModelMatch[1]
+    const className = viewModelMatch[2]
     const tsFile = findViewModelFile(document.uri)
     if (tsFile) {
       return findClassDefinition(tsFile, className)
@@ -48,7 +48,7 @@ function checkViewModelDefinition(document, position, lineText) {
 
 function checkBindAttributeDefinitions(document, position, lineText, forEachInElement) {
   for (const match of lineText.matchAll(BIND_ATTRIBUTE_PATTERN)) {
-    const fullValue = match[1]
+    const fullValue = match[2]
     const attrStartPos = match.index
     const valueStartPos = attrStartPos + match[0].indexOf(fullValue)
     const valueEndPos = valueStartPos + fullValue.length
@@ -58,7 +58,7 @@ function checkBindAttributeDefinitions(document, position, lineText, forEachInEl
       if (!tsFile) continue
 
       const cursorOffsetInValue = position.character - valueStartPos
-      const attrName = match[0].match(/^([^=]+)=/)[1]
+      const attrName = match[0].match(/^([^=]+)=/)[1].trim()
 
       if (attrName === 'for-each') {
         return handleForEachDefinition(fullValue, cursorOffsetInValue, tsFile)
@@ -138,7 +138,7 @@ function handlePropertyPathDefinition(
 
 function checkClickAttributeDefinition(document, position, lineText) {
   for (const match of lineText.matchAll(CLICK_ATTRIBUTE_PATTERN)) {
-    const methodName = match[1]
+    const methodName = match[2]
     const startPos = match.index + match[0].indexOf(methodName)
     const endPos = startPos + methodName.length
 

--- a/tools/pelela-vscode/src/providers/definitionProvider.js
+++ b/tools/pelela-vscode/src/providers/definitionProvider.js
@@ -19,7 +19,7 @@ function provideDefinition(document, position, _token) {
   const viewModelLocation = checkViewModelDefinition(document, position, lineText)
   if (viewModelLocation) return viewModelLocation
 
-  const forEachInElement = findForEachInElement(document, position.line)
+  const forEachInElement = findForEachInElement(document, position.line, position.character)
 
   const bindLocation = checkBindAttributeDefinitions(document, position, lineText, forEachInElement)
   if (bindLocation) return bindLocation

--- a/tools/pelela-vscode/src/providers/definitionProvider.js
+++ b/tools/pelela-vscode/src/providers/definitionProvider.js
@@ -1,6 +1,6 @@
 const vscode = require('vscode')
 const { findViewModelFile } = require('../utils/fileUtils')
-const { findForEachInElement } = require('../parsers/documentParser')
+const { findForEachInElement, parseForEachExpression } = require('../parsers/documentParser')
 const {
   findClassDefinition,
   findPropertyDefinition,
@@ -78,9 +78,10 @@ function checkBindAttributeDefinitions(document, position, lineText, forEachInEl
 }
 
 function handleForEachDefinition(fullValue, cursorOffsetInValue, tsFile) {
-  const forEachMatch = /^\s*(\w+)\s+of\s+(\w+)\s*$/.exec(fullValue)
+  const forEachMatch = parseForEachExpression(`for-each="${fullValue}"`)
   if (forEachMatch) {
-    const collectionName = forEachMatch[2]
+    const { collectionName } = forEachMatch
+
     const collectionStart = fullValue.indexOf(collectionName)
     const collectionEnd = collectionStart + collectionName.length
 
@@ -111,6 +112,17 @@ function handlePropertyPathDefinition(
         return new vscode.Location(
           document.uri,
           new vscode.Position(forEachInElement.line, forEachInElement.itemPos)
+        )
+      }
+
+      if (
+        forEachInElement?.indexName &&
+        part === forEachInElement.indexName &&
+        typeof forEachInElement.indexPos === 'number'
+      ) {
+        return new vscode.Location(
+          document.uri,
+          new vscode.Position(forEachInElement.line, forEachInElement.indexPos)
         )
       }
 

--- a/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
+++ b/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
@@ -165,6 +165,23 @@
           },
           "patterns": [
             {
+              "match": "\\(\\s*(\\w+)\\s*,\\s*(\\w+)\\s*\\)\\s+(of)\\s+(\\w+)\\b",
+              "captures": {
+                "1": {
+                  "name": "variable.other.loop.pelela"
+                },
+                "2": {
+                  "name": "variable.other.loop.pelela"
+                },
+                "3": {
+                  "name": "keyword.operator.pelela"
+                },
+                "4": {
+                  "name": "variable.other.collection.pelela"
+                }
+              }
+            },
+            {
               "match": "\\b(\\w+)\\s+(of)\\s+(\\w+)\\b",
               "captures": {
                 "1": {

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -249,6 +249,24 @@ describe('documentParser', () => {
       assert.strictEqual(lines[1].slice(result.itemPos, result.itemPos + 4), 'item')
       assert.strictEqual(lines[1].slice(result.indexPos, result.indexPos + 3), 'idx')
     })
+
+    it('debería ubicar indexPos correctamente cuando el índice es substring de itemName', () => {
+      const lines = [
+        '<div>',
+        '  <span for-each="(index, in) of items" bind-value="in"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1)
+      assert.strictEqual(lines[1].slice(result.itemPos, result.itemPos + 5), 'index')
+      assert.strictEqual(lines[1].slice(result.indexPos, result.indexPos + 2), 'in')
+      assert.ok(result.indexPos > result.itemPos)
+    })
   })
 
   describe('parsePropertyPath', () => {

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -305,6 +305,29 @@ describe('documentParser', () => {
       assert.strictEqual(result.indexName, 'index')
       assert.strictEqual(result.collectionName, 'items')
     })
+
+    it('debería mantener scope del host multiline aunque haya tags anidados del mismo tipo', () => {
+      const lines = [
+        '<div',
+        '  for-each="(item, index) of items"',
+        '>',
+        '  <div>',
+        '    <span bind-value="item.text"></span>',
+        '  </div>',
+        '  <span bind-value="item.text"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 6, lines[6].length)
+      assert.ok(result)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.indexName, 'index')
+    })
   })
 
   describe('parsePropertyPath', () => {

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -192,6 +192,63 @@ describe('documentParser', () => {
       assert.strictEqual(result.indexName, undefined)
       assert.strictEqual(result.indexPos, undefined)
     })
+
+    it('debería calcular itemPos dentro del valor de for-each y no en otros atributos', () => {
+      const lines = [
+        '<div>',
+        '  <span class="item" for-each="(item, index) of items" bind-value="item.name"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1)
+      const classItemPos = lines[1].indexOf('item')
+      assert.ok(typeof result.itemPos === 'number')
+      assert.ok(result.itemPos > classItemPos)
+      assert.strictEqual(lines[1].slice(result.itemPos, result.itemPos + 4), 'item')
+    })
+
+    it('debería calcular indexPos dentro del valor de for-each aunque exista index en atributos previos', () => {
+      const lines = [
+        '<div>',
+        '  <span data-index="index" for-each="(item, index) of items" bind-value="index"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1)
+      const dataIndexPos = lines[1].indexOf('index')
+      assert.ok(typeof result.indexPos === 'number')
+      assert.ok(result.indexPos > dataIndexPos)
+      assert.strictEqual(lines[1].slice(result.indexPos, result.indexPos + 5), 'index')
+    })
+
+    it('debería calcular posiciones correctamente con for-each entre comillas simples', () => {
+      const lines = [
+        '<div>',
+        "  <span class='item' for-each='(item, idx) of items' bind-value='item.name'></span>",
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.indexName, 'idx')
+      assert.strictEqual(lines[1].slice(result.itemPos, result.itemPos + 4), 'item')
+      assert.strictEqual(lines[1].slice(result.indexPos, result.indexPos + 3), 'idx')
+    })
   })
 
   describe('parsePropertyPath', () => {

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -267,6 +267,23 @@ describe('documentParser', () => {
       assert.strictEqual(lines[1].slice(result.indexPos, result.indexPos + 2), 'in')
       assert.ok(result.indexPos > result.itemPos)
     })
+
+    it('no debería encontrar for-each cuando el cursor está fuera del scope del loop', () => {
+      const lines = [
+        '<div for-each="(item, index) of items">',
+        '  <span bind-value="item.text"></span>',
+        '</div>',
+        '<span bind-value="title"></span>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 3)
+      assert.strictEqual(result, null)
+    })
   })
 
   describe('parsePropertyPath', () => {

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -4,6 +4,7 @@ const {
   isInsideTag,
   isStartingTag,
   getAttributeValueMatch,
+  findForEachInElement,
   parseForEachExpression,
   parsePropertyPath,
 } = require('../../src/parsers/documentParser')
@@ -114,8 +115,31 @@ describe('documentParser', () => {
       })
     })
 
+    it('debería parsear la sintaxis con índice', () => {
+      const result = parseForEachExpression('for-each="(item, index) of items"')
+      assert.deepStrictEqual(result, {
+        itemName: 'item',
+        indexName: 'index',
+        collectionName: 'items',
+      })
+    })
+
+    it('debería parsear la sintaxis con índice personalizado', () => {
+      const result = parseForEachExpression("for-each='(user, i) of users'")
+      assert.deepStrictEqual(result, {
+        itemName: 'user',
+        indexName: 'i',
+        collectionName: 'users',
+      })
+    })
+
     it('debería retornar null si la expresión es inválida', () => {
       const result = parseForEachExpression('for-each="invalid"')
+      assert.strictEqual(result, null)
+    })
+
+    it('debería retornar null si la expresión con índice es inválida', () => {
+      const result = parseForEachExpression('for-each="(item index) of items"')
       assert.strictEqual(result, null)
     })
 
@@ -125,6 +149,48 @@ describe('documentParser', () => {
         itemName: 'item',
         collectionName: 'items',
       })
+    })
+  })
+
+  describe('findForEachInElement', () => {
+    it('debería encontrar for-each con índice e incluir posiciones', () => {
+      const lines = [
+        '<div>',
+        '  <span for-each="(item, idx) of items" bind-value="item.name"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.indexName, 'idx')
+      assert.strictEqual(result.collectionName, 'items')
+      assert.strictEqual(result.line, 1)
+      assert.ok(typeof result.itemPos === 'number')
+      assert.ok(typeof result.indexPos === 'number')
+    })
+
+    it('debería encontrar for-each sin índice manteniendo compatibilidad', () => {
+      const lines = [
+        '<div>',
+        '  <span for-each="item of items" bind-value="item.name"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.collectionName, 'items')
+      assert.strictEqual(result.indexName, undefined)
+      assert.strictEqual(result.indexPos, undefined)
     })
   })
 

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -284,6 +284,27 @@ describe('documentParser', () => {
       const result = findForEachInElement(fakeDocument, 3)
       assert.strictEqual(result, null)
     })
+
+    it('debería encontrar for-each cuando el atributo está en una línea distinta al tag de apertura', () => {
+      const lines = [
+        '<div',
+        '  for-each="(item, index) of items"',
+        '>',
+        '  <span bind-value="item.text"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 3)
+      assert.ok(result)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.indexName, 'index')
+      assert.strictEqual(result.collectionName, 'items')
+    })
   })
 
   describe('parsePropertyPath', () => {

--- a/tools/pelela-vscode/test/parsers/documentParser.test.js
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.js
@@ -30,6 +30,11 @@ describe('documentParser', () => {
       const result = getCurrentAttributeName('<div click = "handler', 21)
       assert.strictEqual(result, 'click')
     })
+
+    it('debería extraer el nombre del atributo con comillas simples', () => {
+      const result = getCurrentAttributeName("<div bind-value='test", 21)
+      assert.strictEqual(result, 'bind-value')
+    })
   })
 
   describe('isInsideTag', () => {
@@ -96,6 +101,11 @@ describe('documentParser', () => {
       const result = getAttributeValueMatch('bind-value = "test')
       assert.strictEqual(result, 'test')
     })
+
+    it('debería extraer el valor cuando usa comillas simples', () => {
+      const result = getAttributeValueMatch("bind-value='test")
+      assert.strictEqual(result, 'test')
+    })
   })
 
   describe('parseForEachExpression', () => {
@@ -147,6 +157,15 @@ describe('documentParser', () => {
       const result = parseForEachExpression('for-each="item of items"')
       assert.deepStrictEqual(result, {
         itemName: 'item',
+        collectionName: 'items',
+      })
+    })
+
+    it('debería parsear for-each con espacios alrededor del signo igual', () => {
+      const result = parseForEachExpression('for-each = "(item, index) of items"')
+      assert.deepStrictEqual(result, {
+        itemName: 'item',
+        indexName: 'index',
         collectionName: 'items',
       })
     })
@@ -324,6 +343,49 @@ describe('documentParser', () => {
       }
 
       const result = findForEachInElement(fakeDocument, 6, lines[6].length)
+      assert.ok(result)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.indexName, 'index')
+    })
+
+    it('debería mantener scope cuando un tag anidado del mismo tipo también es multiline', () => {
+      const lines = [
+        '<div',
+        '  for-each="(item, index) of items"',
+        '>',
+        '  <div',
+        '    class="nested"',
+        '  >',
+        '    <span bind-value="item.text"></span>',
+        '  </div>',
+        '  <span bind-value="item.text"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 8, lines[8].length)
+      assert.ok(result)
+      assert.strictEqual(result.itemName, 'item')
+      assert.strictEqual(result.indexName, 'index')
+    })
+
+    it('debería encontrar for-each cuando el atributo usa espacios alrededor del signo igual', () => {
+      const lines = [
+        '<div>',
+        '  <span for-each = "(item, index) of items" bind-value="item.text"></span>',
+        '</div>',
+      ]
+      const fakeDocument = {
+        lineAt(index) {
+          return { text: lines[index] }
+        },
+      }
+
+      const result = findForEachInElement(fakeDocument, 1, lines[1].length)
       assert.ok(result)
       assert.strictEqual(result.itemName, 'item')
       assert.strictEqual(result.indexName, 'index')

--- a/tools/pelela-vscode/test/providers/completionProvider.test.js
+++ b/tools/pelela-vscode/test/providers/completionProvider.test.js
@@ -71,6 +71,15 @@ interface Item {
     assert.ok(labels.includes('items'))
   })
 
+  it('debería sugerir aliases locales cuando bind-value usa comillas simples', async () => {
+    const lines = ["<div for-each='(item, index) of items'>", "  <span bind-value='", '</div>']
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 1, lines[1].length)
+
+    assert.ok(labels.includes('item'))
+    assert.ok(labels.includes('index'))
+  })
+
   it('no debería sugerir propiedades del view model al comenzar un atributo for-each', async () => {
     const lines = ['<div for-each="']
     const document = createFakeDocument(lines)
@@ -162,5 +171,39 @@ interface Item {
 
     assert.ok(labels.includes('item'))
     assert.ok(labels.includes('index'))
+  })
+
+  it('debería sugerir aliases con tag host y tag anidado multiline del mismo tipo', async () => {
+    const lines = [
+      '<div',
+      '  for-each="(item, index) of items"',
+      '>',
+      '  <div',
+      '    class="nested"',
+      '  >',
+      '    <span bind-value="item.text"></span>',
+      '  </div>',
+      '  <span bind-value="',
+      '</div>',
+    ]
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 8, lines[8].length)
+
+    assert.ok(labels.includes('item'))
+    assert.ok(labels.includes('index'))
+  })
+
+  it('debería sugerir aliases con for-each y bind-value usando espacios alrededor de "="', async () => {
+    const lines = [
+      '<div for-each = "(item, index) of items">',
+      '  <span bind-value = "',
+      '</div>',
+    ]
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 1, lines[1].length)
+
+    assert.ok(labels.includes('item'))
+    assert.ok(labels.includes('index'))
+    assert.ok(labels.includes('items'))
   })
 })

--- a/tools/pelela-vscode/test/providers/completionProvider.test.js
+++ b/tools/pelela-vscode/test/providers/completionProvider.test.js
@@ -129,4 +129,20 @@ interface Item {
     assert.ok(!labels.includes('item'))
     assert.ok(!labels.includes('index'))
   })
+
+  it('debería sugerir aliases locales dentro de for-each con tag multiline', async () => {
+    const lines = [
+      '<div',
+      '  for-each="(item, index) of items"',
+      '>',
+      '  <span bind-value="',
+      '</div>',
+    ]
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 3, lines[3].length)
+
+    assert.ok(labels.includes('item'))
+    assert.ok(labels.includes('index'))
+    assert.ok(labels.includes('items'))
+  })
 })

--- a/tools/pelela-vscode/test/providers/completionProvider.test.js
+++ b/tools/pelela-vscode/test/providers/completionProvider.test.js
@@ -1,0 +1,116 @@
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vscode = require('vscode')
+const { createCompletionProvider } = require('../../src/providers/completionProvider')
+
+describe('completionProvider', () => {
+  const testFilesDir = path.join(__dirname, '../fixtures')
+  const pelelaPath = path.join(testFilesDir, 'completionSample.pelela')
+  const viewModelPath = path.join(testFilesDir, 'completionSample.ts')
+
+  before(() => {
+    if (!fs.existsSync(testFilesDir)) {
+      fs.mkdirSync(testFilesDir, { recursive: true })
+    }
+
+    fs.writeFileSync(
+      viewModelPath,
+      `export class CompletionSample {
+  items: Item[] = [];
+  title: string = "";
+}
+
+interface Item {
+  text: string;
+  visible: boolean;
+}
+`
+    )
+
+    fs.writeFileSync(pelelaPath, '<pelela view-model="CompletionSample"></pelela>\n')
+  })
+
+  after(() => {
+    if (fs.existsSync(pelelaPath)) fs.unlinkSync(pelelaPath)
+    if (fs.existsSync(viewModelPath)) fs.unlinkSync(viewModelPath)
+  })
+
+  function createFakeDocument(lines) {
+    return {
+      uri: vscode.Uri.file(pelelaPath),
+      lineAt(index) {
+        return { text: lines[index] }
+      },
+    }
+  }
+
+  async function getCompletionLabels(document, line, character) {
+    const items = await getCompletionItems(document, line, character)
+    return items.map((item) => item.label)
+  }
+
+  async function getCompletionItems(document, line, character) {
+    createCompletionProvider()
+    const provider = vscode.languages._lastCompletionProvider
+    return await provider.provideCompletionItems(
+      document,
+      new vscode.Position(line, character),
+      undefined,
+      undefined
+    )
+  }
+
+  it('debería sugerir aliases locales de for-each en bind-value vacío', async () => {
+    const lines = ['<div for-each="(item, index) of items">', '  <span bind-value="', '</div>']
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 1, lines[1].length)
+
+    assert.ok(labels.includes('item'))
+    assert.ok(labels.includes('index'))
+    assert.ok(labels.includes('items'))
+  })
+
+  it('no debería sugerir propiedades del view model al comenzar un atributo for-each', async () => {
+    const lines = ['<div for-each="']
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 0, lines[0].length)
+
+    assert.strictEqual(labels.length, 0)
+    assert.ok(!labels.includes('index'))
+    assert.ok(!labels.includes('item'))
+  })
+
+  it('debería sugerir propiedades del view model al completar la colección luego de "of"', async () => {
+    const lines = ['<div for-each="(item, index) of ']
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 0, lines[0].length)
+
+    assert.ok(labels.includes('items'))
+    assert.ok(labels.includes('title'))
+    assert.ok(!labels.includes('index'))
+    assert.ok(!labels.includes('item'))
+  })
+
+  it('debería deduplicar sugerencias cuando un alias local coincide con una propiedad del view model', async () => {
+    const lines = ['<div for-each="(items, index) of items">', '  <span bind-value="', '</div>']
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 1, lines[1].length)
+    const itemsOccurrences = labels.filter((label) => label === 'items').length
+
+    assert.strictEqual(itemsOccurrences, 1)
+  })
+
+  it('debería etiquetar correctamente alias local y propiedad del view model en detalles', async () => {
+    const lines = ['<div for-each="(item, index) of items">', '  <span bind-value="', '</div>']
+    const document = createFakeDocument(lines)
+    const completions = await getCompletionItems(document, 1, lines[1].length)
+    const localItem = completions.find((item) => item.label === 'item')
+    const vmItems = completions.find((item) => item.label === 'items')
+
+    assert.ok(localItem)
+    assert.ok(vmItems)
+    assert.strictEqual(localItem.detail, 'Pelela for-each local variable')
+    assert.strictEqual(vmItems.detail, 'Pelela ViewModel property')
+  })
+})

--- a/tools/pelela-vscode/test/providers/completionProvider.test.js
+++ b/tools/pelela-vscode/test/providers/completionProvider.test.js
@@ -145,4 +145,22 @@ interface Item {
     assert.ok(labels.includes('index'))
     assert.ok(labels.includes('items'))
   })
+
+  it('debería sugerir aliases luego de cerrar un tag anidado del mismo tipo en host multiline', async () => {
+    const lines = [
+      '<div',
+      '  for-each="(item, index) of items"',
+      '>',
+      '  <div>',
+      '    <span bind-value="item.text"></span>',
+      '  </div>',
+      '  <span bind-value="',
+      '</div>',
+    ]
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 6, lines[6].length)
+
+    assert.ok(labels.includes('item'))
+    assert.ok(labels.includes('index'))
+  })
 })

--- a/tools/pelela-vscode/test/providers/completionProvider.test.js
+++ b/tools/pelela-vscode/test/providers/completionProvider.test.js
@@ -113,4 +113,20 @@ interface Item {
     assert.strictEqual(localItem.detail, 'Pelela for-each local variable')
     assert.strictEqual(vmItems.detail, 'Pelela ViewModel property')
   })
+
+  it('no debería sugerir aliases locales fuera del scope de for-each', async () => {
+    const lines = [
+      '<div for-each="(item, index) of items">',
+      '  <span bind-value="item.text"></span>',
+      '</div>',
+      '  <span bind-value="',
+    ]
+    const document = createFakeDocument(lines)
+    const labels = await getCompletionLabels(document, 3, lines[3].length)
+
+    assert.ok(labels.includes('items'))
+    assert.ok(labels.includes('title'))
+    assert.ok(!labels.includes('item'))
+    assert.ok(!labels.includes('index'))
+  })
 })

--- a/tools/pelela-vscode/test/providers/definitionProvider.test.js
+++ b/tools/pelela-vscode/test/providers/definitionProvider.test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const vscode = require('vscode')
+const { createDefinitionProvider } = require('../../src/providers/definitionProvider')
+
+describe('definitionProvider', () => {
+  const testFilesDir = path.join(__dirname, '../fixtures')
+  const pelelaPath = path.join(testFilesDir, 'definitionSample.pelela')
+  const viewModelPath = path.join(testFilesDir, 'definitionSample.ts')
+
+  before(() => {
+    if (!fs.existsSync(testFilesDir)) {
+      fs.mkdirSync(testFilesDir, { recursive: true })
+    }
+
+    fs.writeFileSync(
+      viewModelPath,
+      `export class DefinitionSample {
+  items: Item[] = [];
+  index: number = 123;
+}
+
+interface Item {
+  text: string;
+}
+`
+    )
+
+    fs.writeFileSync(pelelaPath, '<pelela view-model="DefinitionSample"></pelela>\n')
+  })
+
+  after(() => {
+    if (fs.existsSync(pelelaPath)) fs.unlinkSync(pelelaPath)
+    if (fs.existsSync(viewModelPath)) fs.unlinkSync(viewModelPath)
+  })
+
+  function createFakeDocument(lines) {
+    return {
+      uri: vscode.Uri.file(pelelaPath),
+      lineAt(index) {
+        return { text: lines[index] }
+      },
+    }
+  }
+
+  async function getDefinition(document, line, character) {
+    createDefinitionProvider()
+    const provider = vscode.languages._lastDefinitionProvider
+    return await provider.provideDefinition(document, new vscode.Position(line, character), undefined)
+  }
+
+  it('debería resolver colección en for-each con espacios alrededor de "="', async () => {
+    const lines = ['<div for-each = "(item, index) of items"></div>']
+    const document = createFakeDocument(lines)
+    const cursorPos = lines[0].indexOf('items') + 1
+    const location = await getDefinition(document, 0, cursorPos)
+
+    assert.ok(location)
+    assert.strictEqual(location.uri.fsPath, viewModelPath)
+  })
+
+  it('debería resolver alias index en bind-value con comillas simples y espacios alrededor de "="', async () => {
+    const lines = [
+      "<div for-each = '(item, index) of items'>",
+      "  <span bind-value = 'index'></span>",
+      '</div>',
+    ]
+    const document = createFakeDocument(lines)
+    const cursorPos = lines[1].indexOf('index') + 1
+    const location = await getDefinition(document, 1, cursorPos)
+
+    assert.ok(location)
+    assert.strictEqual(location.uri.fsPath, pelelaPath)
+    assert.strictEqual(location.range.start.line, 0)
+  })
+
+  it('fuera del scope del loop debería resolver index como propiedad del view-model', async () => {
+    const lines = [
+      '<div for-each="(item, index) of items">',
+      '  <span bind-value="item.text"></span>',
+      '</div>',
+      '<span bind-value="index"></span>',
+    ]
+    const document = createFakeDocument(lines)
+    const cursorPos = lines[3].indexOf('index') + 1
+    const location = await getDefinition(document, 3, cursorPos)
+
+    assert.ok(location)
+    assert.strictEqual(location.uri.fsPath, viewModelPath)
+  })
+})

--- a/tools/pelela-vscode/test/syntaxes/pelelaGrammar.test.js
+++ b/tools/pelela-vscode/test/syntaxes/pelelaGrammar.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+describe('pelela grammar', () => {
+  const grammarPath = path.join(__dirname, '../../syntaxes/pelela.tmLanguage.json')
+  const grammar = JSON.parse(fs.readFileSync(grammarPath, 'utf-8'))
+  const forEachPatterns = grammar.repository['pelela-attributes'].patterns[0].patterns
+
+  it('debería matchear la sintaxis for-each con índice entre paréntesis', () => {
+    const indexedRegex = new RegExp(forEachPatterns[0].match)
+    const result = indexedRegex.exec('(item, index) of items')
+
+    assert.ok(result)
+    assert.strictEqual(result[1], 'item')
+    assert.strictEqual(result[2], 'index')
+    assert.strictEqual(result[3], 'of')
+    assert.strictEqual(result[4], 'items')
+  })
+
+  it('debería matchear la sintaxis for-each clásica', () => {
+    const defaultRegex = new RegExp(forEachPatterns[1].match)
+    const result = defaultRegex.exec('item of items')
+
+    assert.ok(result)
+    assert.strictEqual(result[1], 'item')
+    assert.strictEqual(result[2], 'of')
+    assert.strictEqual(result[3], 'items')
+  })
+})

--- a/tools/pelela-vscode/test/vscode-stub.cjs
+++ b/tools/pelela-vscode/test/vscode-stub.cjs
@@ -73,8 +73,16 @@ const vscodeStub = {
   },
 
   languages: {
-    registerCompletionItemProvider: () => ({ dispose: () => {} }),
-    registerDefinitionProvider: () => ({ dispose: () => {} }),
+    _lastCompletionProvider: null,
+    _lastDefinitionProvider: null,
+    registerCompletionItemProvider: (_selector, provider) => {
+      vscodeStub.languages._lastCompletionProvider = provider
+      return { dispose: () => {} }
+    },
+    registerDefinitionProvider: (_selector, provider) => {
+      vscodeStub.languages._lastDefinitionProvider = provider
+      return { dispose: () => {} }
+    },
     setTextDocumentLanguage: () => Promise.resolve(),
     setLanguageConfiguration: () => ({ dispose: () => {} }),
   },


### PR DESCRIPTION
## Resumen

Este PR implementa el soporte de índice en `for-each` para PelelaJS:

- Compatibilidad mantenida: `item of items`
- Nueva sintaxis: `(item, index) of items`
- Alias de índice configurable (`i`, `idx`, etc.)
- Índice base 0

## Cambios principales

- **Core**: parseo y render de `for-each` con `indexName`/`indexRef`, manteniendo reconciliación por posición.
- **VSCode**: parser, autocomplete, go-to-definition y syntax highlighting actualizados para la sintaxis con índice.
- **Tests**: cobertura adicional en core y extensión VSCode (parser + completion + grammar).
- **Docs/Ejemplo**: actualización de sintaxis y aclaración de diseño actual sin `key`.

## Validación

- `pnpm -C tools/pelela-vscode test` ✅

## Fuera de alcance

- Soporte de `key` / reconciliación keyed.

## Relacionado
Closes #48 