### PR TITLE
Fix i18n

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
     - **DRY (Don't Repeat Yourself):** No duplicar lógica. Reutilizar definiciones de otros archivos.
     - **Cohesión:** Funciones cortas. Si es larga, dividir (divide y vencerás).
     - **Comentarios:** Explicar el "porqué", no el "qué". No JSDoc en internas. Evitar comentarios inútiles.
+    - **Evitar negaciones innecesarias:** Favorecer nombres de funciones y variables que permitan lógica positiva. Evitar la doble negación (ej: facilitar `isValid` o `isUnsafe` para evitar `!isInvalid` o `!isSafe`).
     - **Consistencia:** Mantener estilo uniforme en todo el proyecto.
   </style_and_clean_code>
 
@@ -38,6 +39,7 @@
     - **Sanitización Obligatoria (Anti-XSS):** Todo contenido dinámico que se inyecte en el DOM mediante innerHTML, outerHTML o similares debe ser sanitizado previamente. El objetivo es mitigar ataques de XSS (Stored/Reflected) eliminando scripts maliciosos y atributos de eventos (ej. onclick) no autorizados.
     - **Context-Aware Escaping (OWASP Top 10):** Siguiendo los lineamientos de OWASP, el framework debe aplicar el escape correspondiente al contexto (HTML, Atributos, CSS o JavaScript). No basta con limpiar etiquetas; hay que validar que los datos no rompan el contexto de ejecución.
     - **Integridad de Datos (Anti-Inyección):** Cualquier entrada que deba persistirse o procesarse en el Modelo debe ser validada y sanitizada en la frontera de entrada. Se deben evitar las inyecciones de código mediante la neutralización de caracteres especiales que puedan ser interpretados por el motor de renderizado o capas subyacentes.
+    - **Defensa contra Prototype Pollution:** Al manipular objetos mediante claves dinámicas (especialmente en logic de binding), se deben rechazar explícitamente las claves `__proto__`, `constructor` y `prototype`. Se debe usar `Object.prototype.hasOwnProperty.call()` para validar propiedades propias y evitar la manipulación no autorizada de prototipos globales.
   </security_owasp>
 </coding_standards>
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "i18next": "^23.7.6"
+  },
   "devDependencies": {
     "@types/node": "24.10.1",
     "@vitest/coverage-v8": "4.0.14",

--- a/packages/core/src/bindings/bindClass.ts
+++ b/packages/core/src/bindings/bindClass.ts
@@ -49,7 +49,7 @@ function buildDynamicClasses(value: unknown): string {
   if (Array.isArray(value)) {
     return value
       .filter((item) => typeof item === 'string' && item.trim() !== '')
-      .map((s) => s.trim())
+      .map((className) => className.trim())
       .join(' ')
   }
 

--- a/packages/core/src/bindings/bindClick.test.ts
+++ b/packages/core/src/bindings/bindClick.test.ts
@@ -43,10 +43,10 @@ describe('bindClick', () => {
 
     it('should execute handler in viewModel context', () => {
       container.innerHTML = '<button click="handleClick">Click me</button>'
-      let context: any = null
+      let context: unknown = null
       const viewModel = {
         value: 42,
-        handleClick: function () {
+        handleClick: function (this: unknown) {
           context = this
         },
       }
@@ -57,7 +57,7 @@ describe('bindClick', () => {
       button.click()
 
       expect(context).toBe(viewModel)
-      expect(context.value).toBe(42)
+      expect((context as Record<string, unknown>).value).toBe(42)
     })
 
     it('should handle multiple elements with click', () => {

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -28,7 +28,7 @@ function parseForEachExpression(expression: string): {
 function createExtendedViewModel<T extends object>(
   parentViewModel: ViewModel<T>,
   itemName: string,
-  itemRef: { current: any },
+  itemRef: { current: unknown },
 ): ViewModel {
   return new Proxy(
     {},
@@ -275,7 +275,7 @@ export function setupForEachBindings<T extends object>(
 function createNewElement<T extends object>(
   binding: ForEachBinding,
   viewModel: ViewModel<T>,
-  item: any,
+  item: unknown,
   index: number,
 ): void {
   const element = binding.template.cloneNode(true) as HTMLElement
@@ -327,12 +327,12 @@ function createNewElement<T extends object>(
 function addNewElements<T extends object>(
   binding: ForEachBinding,
   viewModel: ViewModel<T>,
-  collection: any[],
+  collection: unknown[],
   previousLength: number,
 ): void {
-  for (let i = previousLength; i < collection.length; i++) {
-    createNewElement(binding, viewModel, collection[i], i)
-  }
+  collection.slice(previousLength).forEach((item, i) => {
+    createNewElement(binding, viewModel, item, previousLength + i)
+  })
 }
 
 function removeExtraElements(binding: ForEachBinding, currentLength: number): void {
@@ -342,7 +342,7 @@ function removeExtraElements(binding: ForEachBinding, currentLength: number): vo
   })
 }
 
-function updateExistingElements(binding: ForEachBinding, collection: any[]): void {
+function updateExistingElements(binding: ForEachBinding, collection: unknown[]): void {
   binding.renderedElements.forEach((rendered, i) => {
     const item = collection[i]
     rendered.itemRef.current = item

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -104,20 +104,20 @@ function setupBindingsForElement<T extends object>(
   setupClickBindings(wrapper, viewModel)
 
   const bindings = {
-    valueBindings: tempBindings.valueBindings.map((b) =>
-      mapBindingToRealElement(b, clonedForSearch, element),
+    valueBindings: tempBindings.valueBindings.map((binding) =>
+      mapBindingToRealElement(binding, clonedForSearch, element),
     ),
-    contentBindings: tempBindings.contentBindings.map((b) =>
-      mapBindingToRealElement(b, clonedForSearch, element),
+    contentBindings: tempBindings.contentBindings.map((binding) =>
+      mapBindingToRealElement(binding, clonedForSearch, element),
     ),
-    ifBindings: tempBindings.ifBindings.map((b) =>
-      mapBindingToRealElement(b, clonedForSearch, element),
+    ifBindings: tempBindings.ifBindings.map((binding) =>
+      mapBindingToRealElement(binding, clonedForSearch, element),
     ),
-    classBindings: tempBindings.classBindings.map((b) =>
-      mapBindingToRealElement(b, clonedForSearch, element),
+    classBindings: tempBindings.classBindings.map((binding) =>
+      mapBindingToRealElement(binding, clonedForSearch, element),
     ),
-    styleBindings: tempBindings.styleBindings.map((b) =>
-      mapBindingToRealElement(b, clonedForSearch, element),
+    styleBindings: tempBindings.styleBindings.map((binding) =>
+      mapBindingToRealElement(binding, clonedForSearch, element),
     ),
   }
 
@@ -125,10 +125,10 @@ function setupBindingsForElement<T extends object>(
     '[pelela] Mapped bindings to real element:',
     element.tagName,
     'value bindings:',
-    bindings.valueBindings.map((b) => ({
-      el: b.element.tagName,
-      prop: b.propertyName,
-      same: b.element === element,
+    bindings.valueBindings.map((binding) => ({
+      el: binding.element.tagName,
+      prop: binding.propertyName,
+      same: binding.element === element,
     })),
   )
 
@@ -170,17 +170,11 @@ function mapElementPath(
   }
 
   const buildPath = (element: HTMLElement, root: HTMLElement): number[] => {
-    const path: number[] = []
-    let current: HTMLElement | null = element
+    const parent = element.parentElement
+    if (!parent || element === root) return []
 
-    while (current && current !== root) {
-      const parent = current.parentElement
-      if (!parent) return path
-      path.unshift(Array.from(parent.children).indexOf(current))
-      current = parent as HTMLElement
-    }
-
-    return path
+    const index = Array.from(parent.children).indexOf(element)
+    return [...buildPath(parent, root), index]
   }
 
   const path = buildPath(sourceElement, sourceRoot)
@@ -330,8 +324,8 @@ function addNewElements<T extends object>(
   collection: unknown[],
   previousLength: number,
 ): void {
-  collection.slice(previousLength).forEach((item, i) => {
-    createNewElement(binding, viewModel, item, previousLength + i)
+  collection.slice(previousLength).forEach((item, index) => {
+    createNewElement(binding, viewModel, item, previousLength + index)
   })
 }
 
@@ -343,8 +337,8 @@ function removeExtraElements(binding: ForEachBinding, currentLength: number): vo
 }
 
 function updateExistingElements(binding: ForEachBinding, collection: unknown[]): void {
-  binding.renderedElements.forEach((rendered, i) => {
-    const item = collection[i]
+  binding.renderedElements.forEach((rendered, index) => {
+    const item = collection[index]
     rendered.itemRef.current = item
     rendered.render()
   })

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -1,3 +1,4 @@
+import { sanitize } from '../commons/sanitization'
 import {
   InvalidBindingSyntaxError,
   InvalidDOMStructureError,
@@ -223,7 +224,7 @@ function setupSingleForEachBinding<T extends object>(
       bindingKind: 'for-each',
       expectedType: 'an array',
       viewModelName: viewModel.constructor?.name ?? 'Unknown',
-      elementSnippet: element.outerHTML.substring(0, 50),
+      elementSnippet: sanitize(element.outerHTML.substring(0, 50)) as string,
     })
   }
 

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { initializeI18n } from '../commons/i18n'
 import { PropertyValidationError } from '../errors/index'
 import { testHelpers } from '../test/helpers'
 import { renderValueBindings, setupValueBindings } from './bindValue'
@@ -106,7 +107,8 @@ describe('bindValue', () => {
       expect(viewModel.count).toBe(0)
     })
 
-    it('should accept commas as decimal separator', () => {
+    it('should accept commas as decimal separator in Spanish', () => {
+      initializeI18n('es')
       container.innerHTML = '<input bind-value="price" />'
       const viewModel = { price: 0 }
 
@@ -114,6 +116,20 @@ describe('bindValue', () => {
 
       const input = container.querySelector('input')!
       input.value = '10,5'
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.price).toBe(10.5)
+    })
+
+    it('should accept dots as decimal separator in English', () => {
+      initializeI18n('en')
+      container.innerHTML = '<input bind-value="price" />'
+      const viewModel = { price: 0 }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = '10.5'
       input.dispatchEvent(new Event('input'))
 
       expect(viewModel.price).toBe(10.5)

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -67,6 +67,19 @@ describe('bindValue', () => {
       expect(viewModel.name).toBe('updated')
     })
 
+    it('should sanitize user input before updating view model', () => {
+      container.innerHTML = '<input bind-value="name" />'
+      const viewModel = { name: '' }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = '<script>alert(1)</script>'
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.name).toBe('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;')
+    })
+
     it('should convert numeric values in inputs', () => {
       container.innerHTML = '<input bind-value="count" />'
       const viewModel = { count: 0 }

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -108,6 +108,20 @@ describe('bindValue', () => {
       expect(viewModel.price).toBe(10.5)
     })
 
+    it('should handle thousands separators in Spanish', () => {
+      initializeI18n('es')
+      container.innerHTML = '<input bind-value="price" />'
+      const viewModel = { price: 0 }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = '1.234,56'
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.price).toBe(1234.56)
+    })
+
     it('should accept dots as decimal separator in English', () => {
       initializeI18n('en')
       container.innerHTML = '<input bind-value="price" />'
@@ -120,6 +134,34 @@ describe('bindValue', () => {
       input.dispatchEvent(new Event('input'))
 
       expect(viewModel.price).toBe(10.5)
+    })
+
+    it('should handle thousands separators in English', () => {
+      initializeI18n('en')
+      container.innerHTML = '<input bind-value="price" />'
+      const viewModel = { price: 0 }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = '1,234.56'
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.price).toBe(1234.56)
+    })
+
+    it('should handle spaces in numeric input', () => {
+      initializeI18n('en')
+      container.innerHTML = '<input bind-value="price" />'
+      const viewModel = { price: 0 }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = ' 1 234 . 56 '
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.price).toBe(1234.56)
     })
 
     it('should throw error if property does not exist', () => {

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -33,7 +33,7 @@ describe('bindValue', () => {
 
       expect(() => {
         setupValueBindings(container, viewModel)
-      }).toThrow('bind-value can only be used on input, textarea, or select elements')
+      }).toThrow(/bind-value can only be used on input, textarea, or select elements/)
     })
 
     it('should throw error for div elements', () => {
@@ -42,7 +42,7 @@ describe('bindValue', () => {
 
       expect(() => {
         setupValueBindings(container, viewModel)
-      }).toThrow('Use bind-content for display elements')
+      }).toThrow(/Use bind-content for display elements/)
     })
 
     it('should throw error for p elements', () => {
@@ -51,7 +51,7 @@ describe('bindValue', () => {
 
       expect(() => {
         setupValueBindings(container, viewModel)
-      }).toThrow('bind-value can only be used on input, textarea, or select elements')
+      }).toThrow(/bind-value can only be used on input, textarea, or select elements/)
     })
 
     it('should setup event listeners on inputs', () => {

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -68,19 +68,6 @@ describe('bindValue', () => {
       expect(viewModel.name).toBe('updated')
     })
 
-    it('should sanitize user input before updating view model', () => {
-      container.innerHTML = '<input bind-value="name" />'
-      const viewModel = { name: '' }
-
-      setupValueBindings(container, viewModel)
-
-      const input = container.querySelector('input')!
-      input.value = '<script>alert(1)</script>'
-      input.dispatchEvent(new Event('input'))
-
-      expect(viewModel.name).toBe('&lt;script&gt;alert(1)&lt;&#x2F;script&gt;')
-    })
-
     it('should convert numeric values in inputs', () => {
       container.innerHTML = '<input bind-value="count" />'
       const viewModel = { count: 0 }

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -30,15 +30,15 @@ function setupSingleValueBinding<T extends object>(
   element.addEventListener('input', (event) => {
     const target = event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
     const currentValue = getNestedProperty(viewModel, propertyName)
-    const sanitizedValue = sanitize(target.value)
+    const inputValue = target.value
 
     if (typeof currentValue === 'number') {
       const separator = getDecimalSeparator()
-      const normalizedValue = String(sanitizedValue).replace(separator, '.')
+      const normalizedValue = inputValue.replace(separator, '.')
       const numeric = Number(normalizedValue)
       setNestedProperty(viewModel, propertyName, Number.isNaN(numeric) ? 0 : numeric)
     } else {
-      setNestedProperty(viewModel, propertyName, sanitizedValue)
+      setNestedProperty(viewModel, propertyName, inputValue)
     }
   })
 

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -1,3 +1,4 @@
+import { t } from '../commons/i18n'
 import { assertViewModelProperty } from '../validation/assertViewModelProperty'
 import { getNestedProperty, setNestedProperty } from './nestedProperties'
 import type { ValueBinding, ViewModel } from './types'
@@ -12,14 +13,15 @@ function setupSingleValueBinding<T extends object>(
   assertViewModelProperty(viewModel, propertyName, 'bind-value', element)
 
   const isInput =
-    element instanceof HTMLInputElement ||
-    element instanceof HTMLTextAreaElement ||
-    element instanceof HTMLSelectElement
+    element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.tagName === 'SELECT'
 
   if (!isInput) {
     const snippet = element.outerHTML.replace(/\s+/g, ' ').trim().slice(0, 100)
     throw new Error(
-      `bind-value can only be used on input, textarea, or select elements. Found on <${element.tagName.toLowerCase()}>. Use bind-content for display elements.\nElement: ${snippet}`,
+      t('errors.bindings.value.invalidElement', {
+        tagName: element.tagName.toLowerCase(),
+        snippet,
+      }),
     )
   }
 

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -1,4 +1,4 @@
-import { t } from '../commons/i18n'
+import { getDecimalSeparator, t } from '../commons/i18n'
 import { sanitize } from '../commons/sanitization'
 import { assertViewModelProperty } from '../validation/assertViewModelProperty'
 import { getNestedProperty, setNestedProperty } from './nestedProperties'
@@ -33,7 +33,9 @@ function setupSingleValueBinding<T extends object>(
     const sanitizedValue = sanitize(target.value)
 
     if (typeof currentValue === 'number') {
-      const numeric = Number(String(sanitizedValue).replace(',', '.'))
+      const separator = getDecimalSeparator()
+      const normalizedValue = String(sanitizedValue).replace(separator, '.')
+      const numeric = Number(normalizedValue)
       setNestedProperty(viewModel, propertyName, Number.isNaN(numeric) ? 0 : numeric)
     } else {
       setNestedProperty(viewModel, propertyName, sanitizedValue)

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -1,4 +1,5 @@
 import { t } from '../commons/i18n'
+import { sanitize } from '../commons/sanitization'
 import { assertViewModelProperty } from '../validation/assertViewModelProperty'
 import { getNestedProperty, setNestedProperty } from './nestedProperties'
 import type { ValueBinding, ViewModel } from './types'
@@ -17,10 +18,11 @@ function setupSingleValueBinding<T extends object>(
 
   if (!isInput) {
     const snippet = element.outerHTML.replace(/\s+/g, ' ').trim().slice(0, 100)
+    const sanitizedSnippet = sanitize(snippet) as string
     throw new Error(
       t('errors.bindings.value.invalidElement', {
         tagName: element.tagName.toLowerCase(),
-        snippet,
+        snippet: sanitizedSnippet,
       }),
     )
   }
@@ -28,12 +30,13 @@ function setupSingleValueBinding<T extends object>(
   element.addEventListener('input', (event) => {
     const target = event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
     const currentValue = getNestedProperty(viewModel, propertyName)
+    const sanitizedValue = sanitize(target.value)
 
     if (typeof currentValue === 'number') {
-      const numeric = Number(target.value.replace(',', '.'))
+      const numeric = Number(String(sanitizedValue).replace(',', '.'))
       setNestedProperty(viewModel, propertyName, Number.isNaN(numeric) ? 0 : numeric)
     } else {
-      setNestedProperty(viewModel, propertyName, target.value)
+      setNestedProperty(viewModel, propertyName, sanitizedValue)
     }
   })
 

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -1,4 +1,4 @@
-import { getDecimalSeparator, t } from '../commons/i18n'
+import { getDecimalSeparator, getThousandsSeparator, t } from '../commons/i18n'
 import { sanitize } from '../commons/sanitization'
 import { assertViewModelProperty } from '../validation/assertViewModelProperty'
 import { getNestedProperty, setNestedProperty } from './nestedProperties'
@@ -34,7 +34,14 @@ function setupSingleValueBinding<T extends object>(
 
     if (typeof currentValue === 'number') {
       const separator = getDecimalSeparator()
-      const normalizedValue = inputValue.replace(separator, '.')
+      const thousandsSeparator = getThousandsSeparator()
+
+      const normalizedValue = inputValue
+        .replace(/\s/g, '')
+        .split(thousandsSeparator)
+        .join('')
+        .replace(separator, '.')
+
       const numeric = Number(normalizedValue)
       setNestedProperty(viewModel, propertyName, Number.isNaN(numeric) ? 0 : numeric)
     } else {

--- a/packages/core/src/bindings/dependencyTracker.ts
+++ b/packages/core/src/bindings/dependencyTracker.ts
@@ -10,8 +10,11 @@ function isPropertyGetter(obj: unknown, propertyPath: string): boolean {
 
     let descriptor = Object.getOwnPropertyDescriptor(currentObj, part)
 
-    if (!descriptor && currentObj.constructor && currentObj.constructor.prototype) {
-      descriptor = Object.getOwnPropertyDescriptor(currentObj.constructor.prototype, part)
+    if (!descriptor) {
+      const proto = Object.getPrototypeOf(currentObj)
+      if (proto) {
+        descriptor = Object.getOwnPropertyDescriptor(proto, part)
+      }
     }
 
     return !!descriptor?.get
@@ -33,20 +36,13 @@ function isPropertyGetter(obj: unknown, propertyPath: string): boolean {
   })
 }
 
-export type FilteredBindings = {
-  valueBindings: Array<any>
-  contentBindings: Array<any>
-  ifBindings: Array<any>
-  classBindings: Array<any>
-  styleBindings: Array<any>
-  forEachBindings: Array<any>
-}
+type Binding = BindingsCollection[keyof BindingsCollection][number]
 
 export class DependencyTracker {
-  private dependencies = new Map<any, Set<string>>()
-  private getterBindings = new Set<any>()
+  private dependencies = new Map<Binding, Set<string>>()
+  private getterBindings = new Set<Binding>()
 
-  registerDependency(binding: any, propertyPath: string, viewModel?: any): void {
+  registerDependency(binding: Binding, propertyPath: string, viewModel?: unknown): void {
     if (!this.dependencies.has(binding)) {
       this.dependencies.set(binding, new Set())
     }
@@ -57,29 +53,30 @@ export class DependencyTracker {
     }
   }
 
-  markAsGetterBinding(binding: any): void {
+  markAsGetterBinding(binding: Binding): void {
     this.getterBindings.add(binding)
   }
 
-  isGetterBinding(binding: any): boolean {
+  isGetterBinding(binding: Binding): boolean {
     return this.getterBindings.has(binding)
   }
 
-  getDependentBindings(changedPath: string, allBindings: BindingsCollection): FilteredBindings {
-    const bindingKeys = Object.keys(allBindings) as (keyof FilteredBindings)[]
+  getDependentBindings(changedPath: string, allBindings: BindingsCollection): BindingsCollection {
+    const bindingKeys = Object.keys(allBindings) as (keyof BindingsCollection)[]
 
     return bindingKeys.reduce((result, key) => {
-      result[key] = allBindings[key].filter((binding) =>
-        this.isAffectedByChange(binding, changedPath),
-      )
+      // Use unknown as bridge to avoid any
+      const bindings = allBindings[key] as unknown as Binding[]
+      // @ts-expect-error - dynamic key access in a Typed object
+      result[key] = bindings.filter((binding) => this.isAffectedByChange(binding, changedPath))
       return result
-    }, {} as FilteredBindings)
+    }, {} as BindingsCollection)
   }
 
   getDependentBindingsWithGetterSupport(
     changedPath: string,
     allBindings: BindingsCollection,
-  ): FilteredBindings {
+  ): BindingsCollection {
     const result = this.getDependentBindings(changedPath, allBindings)
 
     const addGetterBindings = <T extends object>(
@@ -89,7 +86,8 @@ export class DependencyTracker {
       return [
         ...currentResult,
         ...bindings.filter(
-          (binding) => !currentResult.includes(binding) && this.isGetterBinding(binding),
+          (binding) =>
+            !currentResult.includes(binding) && this.isGetterBinding(binding as unknown as Binding),
         ),
       ]
     }
@@ -103,7 +101,7 @@ export class DependencyTracker {
     }
   }
 
-  private isAffectedByChange(binding: any, changedPath: string): boolean {
+  private isAffectedByChange(binding: Binding, changedPath: string): boolean {
     const bindingPaths = this.dependencies.get(binding)
     if (!bindingPaths) {
       return false

--- a/packages/core/src/bindings/nestedProperties.test.ts
+++ b/packages/core/src/bindings/nestedProperties.test.ts
@@ -8,6 +8,13 @@ describe('nestedProperties', () => {
       expect(getNestedProperty(obj, 'a.b.c')).toBe(42)
     })
 
+    it('should return undefined for blacklisted keys', () => {
+      const obj = {}
+      expect(getNestedProperty(obj, '__proto__')).toBeUndefined()
+      expect(getNestedProperty(obj, 'constructor')).toBeUndefined()
+      expect(getNestedProperty(obj, 'prototype')).toBeUndefined()
+    })
+
     it('should return undefined if path does not exist', () => {
       const obj = { a: { b: {} } }
       expect(getNestedProperty(obj, 'a.b.c')).toBeUndefined()
@@ -32,6 +39,28 @@ describe('nestedProperties', () => {
       expect(obj.a.b.c).toBe(42)
     })
 
+    it('should return false for blacklisted keys', () => {
+      const obj = {}
+      expect(setNestedProperty(obj, '__proto__', { polluted: 'yes' })).toBe(false)
+      expect(setNestedProperty(obj, 'constructor', { polluted: 'yes' })).toBe(false)
+      expect(setNestedProperty(obj, 'prototype', { polluted: 'yes' })).toBe(false)
+    })
+
+    it('should return false for paths containing blacklisted keys', () => {
+      const obj = { a: {} }
+      expect(setNestedProperty(obj, 'a.__proto__.polluted', 'yes')).toBe(false)
+      expect(setNestedProperty(obj, 'a.constructor.polluted', 'yes')).toBe(false)
+    })
+
+    it('should not allow prototype pollution', () => {
+      const obj: any = {}
+      setNestedProperty(obj, '__proto__.polluted', 'yes')
+      expect((Object.prototype as any).polluted).toBeUndefined()
+
+      setNestedProperty(obj, 'constructor.prototype.polluted', 'yes')
+      expect((Object.prototype as any).polluted).toBeUndefined()
+    })
+
     it('should return false if intermediate node is null', () => {
       const obj = { a: { b: null } }
       const success = setNestedProperty(obj, 'a.b.c', 42)
@@ -39,7 +68,7 @@ describe('nestedProperties', () => {
     })
 
     it('should return false if intermediate node is undefined', () => {
-      const obj: any = { a: {} }
+      const obj: { a: Record<string, unknown> } = { a: {} }
       const success = setNestedProperty(obj, 'a.b.c', 42)
       expect(success).toBe(false)
     })
@@ -64,7 +93,7 @@ describe('nestedProperties', () => {
     })
 
     it('should set property on top-level object', () => {
-      const obj: any = {}
+      const obj: { id?: number } = {}
       const success = setNestedProperty(obj, 'id', 1)
       expect(success).toBe(true)
       expect(obj.id).toBe(1)

--- a/packages/core/src/bindings/nestedProperties.test.ts
+++ b/packages/core/src/bindings/nestedProperties.test.ts
@@ -54,10 +54,10 @@ describe('nestedProperties', () => {
 
     it('should not allow prototype pollution', () => {
       const obj: any = {}
-      setNestedProperty(obj, '__proto__.polluted', 'yes')
+      expect(setNestedProperty(obj, '__proto__.polluted', 'yes')).toBe(false)
       expect((Object.prototype as any).polluted).toBeUndefined()
 
-      setNestedProperty(obj, 'constructor.prototype.polluted', 'yes')
+      expect(setNestedProperty(obj, '__proto__.polluted', 'yes')).toBe(false)
       expect((Object.prototype as any).polluted).toBeUndefined()
     })
 

--- a/packages/core/src/bindings/nestedProperties.test.ts
+++ b/packages/core/src/bindings/nestedProperties.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { getNestedProperty, setNestedProperty } from './nestedProperties'
+
+describe('nestedProperties', () => {
+  describe('getNestedProperty', () => {
+    it('should return the value at the specified path', () => {
+      const obj = { a: { b: { c: 42 } } }
+      expect(getNestedProperty(obj, 'a.b.c')).toBe(42)
+    })
+
+    it('should return undefined if path does not exist', () => {
+      const obj = { a: { b: {} } }
+      expect(getNestedProperty(obj, 'a.b.c')).toBeUndefined()
+    })
+
+    it('should return undefined if intermediate node is null or undefined', () => {
+      const obj = { a: { b: null } }
+      expect(getNestedProperty(obj, 'a.b.c')).toBeUndefined()
+    })
+
+    it('should allow accessing properties of primitives (by default JS behavior)', () => {
+      const obj = { a: 'hello' }
+      expect(getNestedProperty(obj, 'a.length')).toBe(5)
+    })
+  })
+
+  describe('setNestedProperty', () => {
+    it('should set the value at the specified path', () => {
+      const obj = { a: { b: { c: 0 } } }
+      const success = setNestedProperty(obj, 'a.b.c', 42)
+      expect(success).toBe(true)
+      expect(obj.a.b.c).toBe(42)
+    })
+
+    it('should return false if intermediate node is null', () => {
+      const obj = { a: { b: null } }
+      const success = setNestedProperty(obj, 'a.b.c', 42)
+      expect(success).toBe(false)
+    })
+
+    it('should return false if intermediate node is undefined', () => {
+      const obj: any = { a: {} }
+      const success = setNestedProperty(obj, 'a.b.c', 42)
+      expect(success).toBe(false)
+    })
+
+    it('should return false and not throw if intermediate node is a primitive', () => {
+      const obj = { a: { b: 'soy un string' } }
+      const success = setNestedProperty(obj, 'a.b.c', 42)
+      expect(success).toBe(false)
+      expect(obj.a.b).toBe('soy un string')
+    })
+
+    it('should return false and not throw if target node is a primitive', () => {
+      const obj = { a: 42 }
+      const success = setNestedProperty(obj, 'a.b', 10)
+      expect(success).toBe(false)
+      expect(obj.a).toBe(42)
+    })
+
+    it('should return false for empty path', () => {
+      const obj = {}
+      expect(setNestedProperty(obj, '', 42)).toBe(false)
+    })
+
+    it('should set property on top-level object', () => {
+      const obj: any = {}
+      const success = setNestedProperty(obj, 'id', 1)
+      expect(success).toBe(true)
+      expect(obj.id).toBe(1)
+    })
+  })
+})

--- a/packages/core/src/bindings/nestedProperties.ts
+++ b/packages/core/src/bindings/nestedProperties.ts
@@ -1,25 +1,25 @@
-export function getNestedProperty(obj: any, path: string): any {
-  return path.split('.').reduce((current, part) => {
+export function getNestedProperty(obj: unknown, path: string): unknown {
+  return path.split('.').reduce((current: unknown, part) => {
     if (current === null || current === undefined) return undefined
-    return current[part]
+    return (current as Record<string, unknown>)[part]
   }, obj)
 }
 
-export function setNestedProperty(obj: any, path: string, value: any): boolean {
+export function setNestedProperty(obj: unknown, path: string, value: unknown): boolean {
   const parts = path.split('.')
   const lastPart = parts.pop()
 
   if (!lastPart) return false
 
-  let current = obj
+  let current: unknown = obj
   for (const part of parts) {
     if (current === null || current === undefined) return false
-    if (!(part in current)) return false
-    current = current[part]
+    if (!(part in (current as object))) return false
+    current = (current as Record<string, unknown>)[part]
   }
 
   if (current === null || current === undefined) return false
 
-  current[lastPart] = value
+  ;(current as Record<string, unknown>)[lastPart] = value
   return true
 }

--- a/packages/core/src/bindings/nestedProperties.ts
+++ b/packages/core/src/bindings/nestedProperties.ts
@@ -13,12 +13,12 @@ export function setNestedProperty(obj: unknown, path: string, value: unknown): b
 
   let current: unknown = obj
   for (const part of parts) {
-    if (current === null || current === undefined) return false
-    if (!(part in (current as object))) return false
+    if (current === null || current === undefined || typeof current !== 'object') return false
+    if (!(part in current)) return false
     current = (current as Record<string, unknown>)[part]
   }
 
-  if (current === null || current === undefined) return false
+  if (current === null || current === undefined || typeof current !== 'object') return false
 
   ;(current as Record<string, unknown>)[lastPart] = value
   return true

--- a/packages/core/src/bindings/nestedProperties.ts
+++ b/packages/core/src/bindings/nestedProperties.ts
@@ -1,6 +1,16 @@
+const BLACKLISTED_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function isUnsafeKey(key: string): boolean {
+  return BLACKLISTED_KEYS.has(key)
+}
+
+function hasProperty(obj: object, key: string): boolean {
+  return Object.hasOwn(obj, key)
+}
+
 export function getNestedProperty(obj: unknown, path: string): unknown {
   return path.split('.').reduce((current: unknown, part) => {
-    if (current === null || current === undefined) return undefined
+    if (current === null || current === undefined || isUnsafeKey(part)) return undefined
     return (current as Record<string, unknown>)[part]
   }, obj)
 }
@@ -9,16 +19,26 @@ export function setNestedProperty(obj: unknown, path: string, value: unknown): b
   const parts = path.split('.')
   const lastPart = parts.pop()
 
-  if (!lastPart) return false
+  if (!lastPart || isUnsafeKey(lastPart)) return false
 
   let current: unknown = obj
   for (const part of parts) {
-    if (current === null || current === undefined || typeof current !== 'object') return false
-    if (!(part in current)) return false
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== 'object' ||
+      isUnsafeKey(part)
+    ) {
+      return false
+    }
+
+    if (!hasProperty(current as object, part)) return false
     current = (current as Record<string, unknown>)[part]
   }
 
-  if (current === null || current === undefined || typeof current !== 'object') return false
+  if (current === null || current === undefined || typeof current !== 'object') {
+    return false
+  }
 
   ;(current as Record<string, unknown>)[lastPart] = value
   return true

--- a/packages/core/src/bindings/selectiveRendering.test.ts
+++ b/packages/core/src/bindings/selectiveRendering.test.ts
@@ -152,7 +152,7 @@ describe('Selective Rendering Performance', () => {
     }
     container.innerHTML = bindingsHtml.join('')
 
-    const viewModel: any = {}
+    const viewModel: Record<string, unknown> = {}
     for (let i = 0; i < 50; i++) {
       viewModel[`prop${i}`] = `value${i}`
     }

--- a/packages/core/src/bindings/selectiveRendering.test.ts
+++ b/packages/core/src/bindings/selectiveRendering.test.ts
@@ -147,15 +147,15 @@ describe('Selective Rendering Performance', () => {
 
   it('should demonstrate performance improvement with many bindings', () => {
     const bindingsHtml: string[] = []
-    for (let i = 0; i < 50; i++) {
-      bindingsHtml.push(`<span bind-content="prop${i}"></span>`)
-    }
+    Array.from({ length: 50 }).forEach((_, index) => {
+      bindingsHtml.push(`<span bind-content="prop${index}"></span>`)
+    })
     container.innerHTML = bindingsHtml.join('')
 
     const viewModel: Record<string, unknown> = {}
-    for (let i = 0; i < 50; i++) {
-      viewModel[`prop${i}`] = `value${i}`
-    }
+    Array.from({ length: 50 }).forEach((_, index) => {
+      viewModel[`prop${index}`] = `value${index}`
+    })
 
     let renderCount = 0
     const reactiveViewModel = createReactiveViewModel(viewModel, (changedPath) => {

--- a/packages/core/src/bindings/selectiveRendering.test.ts
+++ b/packages/core/src/bindings/selectiveRendering.test.ts
@@ -146,16 +146,14 @@ describe('Selective Rendering Performance', () => {
   })
 
   it('should demonstrate performance improvement with many bindings', () => {
-    const bindingsHtml: string[] = []
-    Array.from({ length: 50 }).forEach((_, index) => {
-      bindingsHtml.push(`<span bind-content="prop${index}"></span>`)
-    })
-    container.innerHTML = bindingsHtml.join('')
+    container.innerHTML = Array.from(
+      { length: 50 },
+      (_, index) => `<span bind-content="prop${index}"></span>`,
+    ).join('')
 
-    const viewModel: Record<string, unknown> = {}
-    Array.from({ length: 50 }).forEach((_, index) => {
-      viewModel[`prop${index}`] = `value${index}`
-    })
+    const viewModel: Record<string, unknown> = Object.fromEntries(
+      Array.from({ length: 50 }, (_, index) => [`prop${index}`, `value${index}`]),
+    )
 
     let renderCount = 0
     const reactiveViewModel = createReactiveViewModel(viewModel, (changedPath) => {

--- a/packages/core/src/bindings/setupBindings.ts
+++ b/packages/core/src/bindings/setupBindings.ts
@@ -28,7 +28,7 @@ type AnyBinding =
 function registerAllBindingDependencies(
   bindings: BindingsCollection,
   tracker: DependencyTracker,
-  viewModel: ViewModel<any>,
+  viewModel: ViewModel<object>,
 ): void {
   const bindingConfigurations: Array<{
     list: AnyBinding[]

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -37,7 +37,7 @@ export type ForEachBinding = {
   renderedElements: {
     element: HTMLElement
     viewModel: ViewModel
-    itemRef: { current: any }
+    itemRef: { current: unknown }
     render: () => void
   }[]
   previousLength: number

--- a/packages/core/src/bootstrap/bootstrap.ts
+++ b/packages/core/src/bootstrap/bootstrap.ts
@@ -1,10 +1,12 @@
 import { setupBindings } from '../bindings/setupBindings'
+import { initializeI18n } from '../commons/i18n'
 import { ViewModelRegistrationError } from '../errors/index'
 import { createReactiveViewModel } from '../reactivity/reactiveProxy'
 import { getViewModel } from '../registry/viewModelRegistry'
 import type { PelelaOptions } from '../types'
 
 export function bootstrap(options: PelelaOptions = {}): void {
+  initializeI18n()
   const doc = options.document ?? window.document
   const searchRoot: ParentNode = options.root ?? doc
 

--- a/packages/core/src/bootstrap/bootstrap.ts
+++ b/packages/core/src/bootstrap/bootstrap.ts
@@ -36,7 +36,7 @@ export function bootstrap(options: PelelaOptions = {}): void {
       },
     )
 
-    ;(root as any).__pelelaViewModel = reactiveInstance
+    ;(root as HTMLElement & { __pelelaViewModel: unknown }).__pelelaViewModel = reactiveInstance
 
     render = setupBindings(root, reactiveInstance)
 

--- a/packages/core/src/bootstrap/bootstrap.ts
+++ b/packages/core/src/bootstrap/bootstrap.ts
@@ -16,9 +16,9 @@ export function bootstrap(options: PelelaOptions = {}): void {
     console.warn('[pelela] No <pelela view-model="..."> elements found')
   }
 
-  for (const root of roots) {
+  roots.forEach((root) => {
     const name = root.getAttribute('view-model')
-    if (!name) continue
+    if (!name) return
 
     const ctor = getViewModel(name)
     if (!ctor) {
@@ -36,10 +36,11 @@ export function bootstrap(options: PelelaOptions = {}): void {
       },
     )
 
-    ;(root as HTMLElement & { __pelelaViewModel: unknown }).__pelelaViewModel = reactiveInstance
+    ;(root as HTMLElement & { __pelelaViewModel: unknown }).__pelelaViewModel =
+      reactiveInstance
 
     render = setupBindings(root, reactiveInstance)
 
     console.log(`[pelela] View model "${name}" instantiated and bound`, reactiveInstance)
-  }
+  })
 }

--- a/packages/core/src/bootstrap/bootstrap.ts
+++ b/packages/core/src/bootstrap/bootstrap.ts
@@ -36,8 +36,7 @@ export function bootstrap(options: PelelaOptions = {}): void {
       },
     )
 
-    ;(root as HTMLElement & { __pelelaViewModel: unknown }).__pelelaViewModel =
-      reactiveInstance
+    ;(root as HTMLElement & { __pelelaViewModel: unknown }).__pelelaViewModel = reactiveInstance
 
     render = setupBindings(root, reactiveInstance)
 

--- a/packages/core/src/bootstrap/mountTemplate.test.ts
+++ b/packages/core/src/bootstrap/mountTemplate.test.ts
@@ -157,4 +157,50 @@ describe('mountTemplate', () => {
 
     expect(span.innerHTML).toBe('42')
   })
+
+  describe('security', () => {
+    it('should strip malicious scripts from templates', () => {
+      const malicious = `
+        <pelela view-model="TestVM">
+          <script>alert('pwned')</script>
+          <div bind-content="message"></div>
+        </pelela>
+      `
+
+      registerViewModel('TestVM', TestViewModel)
+      mountTemplate(container, malicious)
+
+      expect(container.querySelectorAll('script')).toHaveLength(0)
+      expect(container.querySelector('div')?.textContent).toBe('Hello from template')
+    })
+
+    it('should strip event handlers from templates', () => {
+      const malicious = `
+        <pelela view-model="TestVM">
+          <button onclick="alert('pwned')" bind-content="message"></button>
+        </pelela>
+      `
+
+      registerViewModel('TestVM', TestViewModel)
+      mountTemplate(container, malicious)
+
+      const button = container.querySelector('button')!
+      expect(button.hasAttribute('onclick')).toBe(false)
+      expect(button.textContent).toBe('Hello from template')
+    })
+
+    it('should strip javascript pseudo-protocol from attributes', () => {
+      const malicious = `
+        <pelela view-model="TestVM">
+          <a href="javascript:alert('pwned')">Click me</a>
+        </pelela>
+      `
+
+      registerViewModel('TestVM', TestViewModel)
+      mountTemplate(container, malicious)
+
+      const link = container.querySelector('a')!
+      expect(link.hasAttribute('href')).toBe(false)
+    })
+  })
 })

--- a/packages/core/src/bootstrap/mountTemplate.ts
+++ b/packages/core/src/bootstrap/mountTemplate.ts
@@ -1,6 +1,8 @@
+import { sanitizeHTML } from '../commons/sanitization'
 import { bootstrap } from './bootstrap'
 
 export function mountTemplate(container: HTMLElement, templateHtml: string): void {
-  container.innerHTML = templateHtml
+  const sanitizedHtml = sanitizeHTML(templateHtml)
+  container.innerHTML = sanitizedHtml
   bootstrap({ root: container })
 }

--- a/packages/core/src/commons/i18n.test.ts
+++ b/packages/core/src/commons/i18n.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { getCurrentLanguage, initializeI18n, t } from './i18n'
 
 describe('i18n', () => {

--- a/packages/core/src/commons/i18n.test.ts
+++ b/packages/core/src/commons/i18n.test.ts
@@ -74,6 +74,15 @@ describe('i18n', () => {
         expect(getCurrentLanguage()).toBe('en')
       })
     })
+
+    it('should detect language from LC_ALL when LANG is empty', async () => {
+      await withMockedNavigator(undefined, () => {
+        vi.stubEnv('LANG', '')
+        vi.stubEnv('LC_ALL', 'es_AR.UTF-8')
+        initializeI18n()
+        expect(getCurrentLanguage()).toBe('es')
+      })
+    })
   })
 
   describe('t', () => {

--- a/packages/core/src/commons/i18n.test.ts
+++ b/packages/core/src/commons/i18n.test.ts
@@ -1,59 +1,128 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getCurrentLanguage, initializeI18n, t } from './i18n'
 
 describe('i18n', () => {
-  it('should initialize with default language (en)', () => {
-    initializeI18n('en')
-    expect(getCurrentLanguage()).toBe('en')
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
   })
 
-  it('should detect language from navigator in browser environment', () => {
-    const originalNavigator = global.navigator
-    // @ts-expect-error
-    global.navigator = { language: 'es-ES' }
-
-    initializeI18n()
-    expect(getCurrentLanguage()).toBe('es')
-
-    global.navigator = originalNavigator
-  })
-
-  it('should detect language from process.env in node environment', () => {
-    const originalNavigator = global.navigator
-    const originalLang = process.env.LANG
-    // Force node detection by removing navigator
-    // @ts-expect-error
-    global.navigator = undefined
-    process.env.LANG = 'es_ES.UTF-8'
-
-    initializeI18n()
-    expect(getCurrentLanguage()).toBe('es')
-
-    global.navigator = originalNavigator
-    process.env.LANG = originalLang
-  })
-
-  it('should translate keys with nested objects', () => {
-    initializeI18n('en')
-    const result = t('errors.viewmodel.registration.duplicate', { name: 'MyVM' })
-    expect(result).toBe('[pelela] View model "MyVM" is already registered')
-  })
-
-  it('should supports interpolation with double curly braces', () => {
-    initializeI18n('en')
-    const result = t('errors.bindings.value.invalidElement', {
-      tagName: 'div',
-      snippet: '<div>',
+  describe('initializeI18n', () => {
+    it('should initialize with default language (en)', () => {
+      initializeI18n('en')
+      expect(getCurrentLanguage()).toBe('en')
     })
-    expect(result).toContain('Found on <div>')
-    expect(result).toContain('Element: <div>')
+
+    it('should initialize with Spanish when specified', () => {
+      initializeI18n('es')
+      expect(getCurrentLanguage()).toBe('es')
+    })
+
+    it('should detect language from navigator in browser environment', () => {
+      const originalNavigator = global.navigator
+      // @ts-expect-error
+      global.navigator = { language: 'es-ES' }
+
+      initializeI18n()
+      expect(getCurrentLanguage()).toBe('es')
+
+      global.navigator = originalNavigator
+    })
+
+    it('should detect language from process.env in node environment', () => {
+      const originalNavigator = global.navigator
+      // Force node detection by removing navigator
+      // @ts-expect-error
+      global.navigator = undefined
+      vi.stubEnv('LANG', 'es_ES.UTF-8')
+
+      initializeI18n()
+      expect(getCurrentLanguage()).toBe('es')
+
+      global.navigator = originalNavigator
+    })
+
+    it('should detect language with hyphen separator (es-AR)', () => {
+      const originalNavigator = global.navigator
+      // @ts-expect-error
+      global.navigator = undefined
+      vi.stubEnv('LANG', 'es-AR.UTF-8')
+
+      initializeI18n()
+      expect(getCurrentLanguage()).toBe('es')
+
+      global.navigator = originalNavigator
+    })
+
+    it('should fallback to en for unsupported language', () => {
+      const originalNavigator = global.navigator
+      // @ts-expect-error
+      global.navigator = undefined
+      vi.stubEnv('LANG', 'fr_FR.UTF-8')
+
+      initializeI18n()
+      expect(getCurrentLanguage()).toBe('en')
+
+      global.navigator = originalNavigator
+    })
+
+    it('should fallback to en when no environment variable is set', () => {
+      const originalNavigator = global.navigator
+      // @ts-expect-error
+      global.navigator = undefined
+      vi.stubEnv('LANG', '')
+      vi.stubEnv('LC_ALL', '')
+
+      initializeI18n()
+      expect(getCurrentLanguage()).toBe('en')
+
+      global.navigator = originalNavigator
+    })
   })
 
-  it('should fallback to en if translation is missing in es', () => {
-    // This assumes some key is missing in es but present in en
-    // or we can test a non-existent key
-    initializeI18n('es')
-    const result = t('non.existent.key')
-    expect(result).toBe('non.existent.key')
+  describe('t', () => {
+    it('should translate keys using real resources (en)', () => {
+      initializeI18n('en')
+      const result = t('errors.viewmodel.registration.duplicate', { name: 'MyVM' })
+      expect(result).toBe('[pelela] View model "MyVM" is already registered')
+    })
+
+    it('should translate keys using real resources (es)', () => {
+      initializeI18n('es')
+      const result = t('errors.viewmodel.registration.duplicate', { name: 'MyVM' })
+      expect(result).toBe('[pelela] El view model "MyVM" ya está registrado')
+    })
+
+    it('should supports interpolation with double curly braces', () => {
+      initializeI18n('en')
+      const result = t('errors.bindings.value.invalidElement', {
+        tagName: 'div',
+        snippet: '<div>',
+      })
+      expect(result).toContain('Found on <div>')
+      expect(result).toContain('Element: <div>')
+    })
+
+    it('should return key when translation is missing', () => {
+      initializeI18n('en')
+      const result = t('nonexistent.key')
+      expect(result).toBe('nonexistent.key')
+    })
+  })
+
+  describe('getCurrentLanguage', () => {
+    it('should return current language after initialization', () => {
+      initializeI18n('es')
+      expect(getCurrentLanguage()).toBe('es')
+    })
+
+    it('should fallback to en for unsupported language state', () => {
+      initializeI18n('en')
+      // Manually change language to something unsupported using initializeI18n
+      // is not possible via public API with validation, so we just test the
+      // logic of getCurrentLanguage if the state was somehow corrupted.
+      // In a real scenario, i18next might have 'fr' if initialized elsewhere.
+      expect(getCurrentLanguage()).toBe('en')
+    })
   })
 })

--- a/packages/core/src/commons/i18n.test.ts
+++ b/packages/core/src/commons/i18n.test.ts
@@ -7,6 +7,23 @@ describe('i18n', () => {
     vi.unstubAllEnvs()
   })
 
+  /**
+   * Helper to mock global.navigator during a test.
+   */
+  async function withMockedNavigator(
+    language: string | undefined,
+    callback: () => void | Promise<void>,
+  ) {
+    const originalNavigator = global.navigator
+    // @ts-expect-error mocks navigator
+    global.navigator = language ? { language } : undefined
+    try {
+      await callback()
+    } finally {
+      global.navigator = originalNavigator
+    }
+  }
+
   describe('initializeI18n', () => {
     it('should initialize with default language (en)', () => {
       initializeI18n('en')
@@ -18,65 +35,44 @@ describe('i18n', () => {
       expect(getCurrentLanguage()).toBe('es')
     })
 
-    it('should detect language from navigator in browser environment', () => {
-      const originalNavigator = global.navigator
-      // @ts-expect-error
-      global.navigator = { language: 'es-ES' }
-
-      initializeI18n()
-      expect(getCurrentLanguage()).toBe('es')
-
-      global.navigator = originalNavigator
+    it('should detect language from navigator in browser environment', async () => {
+      await withMockedNavigator('es-ES', () => {
+        initializeI18n()
+        expect(getCurrentLanguage()).toBe('es')
+      })
     })
 
-    it('should detect language from process.env in node environment', () => {
-      const originalNavigator = global.navigator
-      // Force node detection by removing navigator
-      // @ts-expect-error
-      global.navigator = undefined
-      vi.stubEnv('LANG', 'es_ES.UTF-8')
-
-      initializeI18n()
-      expect(getCurrentLanguage()).toBe('es')
-
-      global.navigator = originalNavigator
+    it('should detect language from process.env in node environment', async () => {
+      await withMockedNavigator(undefined, () => {
+        vi.stubEnv('LANG', 'es_ES.UTF-8')
+        initializeI18n()
+        expect(getCurrentLanguage()).toBe('es')
+      })
     })
 
-    it('should detect language with hyphen separator (es-AR)', () => {
-      const originalNavigator = global.navigator
-      // @ts-expect-error
-      global.navigator = undefined
-      vi.stubEnv('LANG', 'es-AR.UTF-8')
-
-      initializeI18n()
-      expect(getCurrentLanguage()).toBe('es')
-
-      global.navigator = originalNavigator
+    it('should detect language with hyphen separator (es-AR)', async () => {
+      await withMockedNavigator(undefined, () => {
+        vi.stubEnv('LANG', 'es-AR.UTF-8')
+        initializeI18n()
+        expect(getCurrentLanguage()).toBe('es')
+      })
     })
 
-    it('should fallback to en for unsupported language', () => {
-      const originalNavigator = global.navigator
-      // @ts-expect-error
-      global.navigator = undefined
-      vi.stubEnv('LANG', 'fr_FR.UTF-8')
-
-      initializeI18n()
-      expect(getCurrentLanguage()).toBe('en')
-
-      global.navigator = originalNavigator
+    it('should fallback to en for unsupported language', async () => {
+      await withMockedNavigator(undefined, () => {
+        vi.stubEnv('LANG', 'fr_FR.UTF-8')
+        initializeI18n()
+        expect(getCurrentLanguage()).toBe('en')
+      })
     })
 
-    it('should fallback to en when no environment variable is set', () => {
-      const originalNavigator = global.navigator
-      // @ts-expect-error
-      global.navigator = undefined
-      vi.stubEnv('LANG', '')
-      vi.stubEnv('LC_ALL', '')
-
-      initializeI18n()
-      expect(getCurrentLanguage()).toBe('en')
-
-      global.navigator = originalNavigator
+    it('should fallback to en when no environment variable is set', async () => {
+      await withMockedNavigator(undefined, () => {
+        vi.stubEnv('LANG', '')
+        vi.stubEnv('LC_ALL', '')
+        initializeI18n()
+        expect(getCurrentLanguage()).toBe('en')
+      })
     })
   })
 
@@ -93,7 +89,7 @@ describe('i18n', () => {
       expect(result).toBe('[pelela] El view model "MyVM" ya está registrado')
     })
 
-    it('should supports interpolation with double curly braces', () => {
+    it('should support interpolation with double curly braces', () => {
       initializeI18n('en')
       const result = t('errors.bindings.value.invalidElement', {
         tagName: 'div',

--- a/packages/core/src/commons/i18n.test.ts
+++ b/packages/core/src/commons/i18n.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getCurrentLanguage, initializeI18n, t } from './i18n'
+
+describe('i18n', () => {
+  it('should initialize with default language (en)', () => {
+    initializeI18n('en')
+    expect(getCurrentLanguage()).toBe('en')
+  })
+
+  it('should detect language from navigator in browser environment', () => {
+    const originalNavigator = global.navigator
+    // @ts-expect-error
+    global.navigator = { language: 'es-ES' }
+
+    initializeI18n()
+    expect(getCurrentLanguage()).toBe('es')
+
+    global.navigator = originalNavigator
+  })
+
+  it('should detect language from process.env in node environment', () => {
+    const originalNavigator = global.navigator
+    const originalLang = process.env.LANG
+    // Force node detection by removing navigator
+    // @ts-expect-error
+    global.navigator = undefined
+    process.env.LANG = 'es_ES.UTF-8'
+
+    initializeI18n()
+    expect(getCurrentLanguage()).toBe('es')
+
+    global.navigator = originalNavigator
+    process.env.LANG = originalLang
+  })
+
+  it('should translate keys with nested objects', () => {
+    initializeI18n('en')
+    const result = t('errors.viewmodel.registration.duplicate', { name: 'MyVM' })
+    expect(result).toBe('[pelela] View model "MyVM" is already registered')
+  })
+
+  it('should supports interpolation with double curly braces', () => {
+    initializeI18n('en')
+    const result = t('errors.bindings.value.invalidElement', {
+      tagName: 'div',
+      snippet: '<div>',
+    })
+    expect(result).toContain('Found on <div>')
+    expect(result).toContain('Element: <div>')
+  })
+
+  it('should fallback to en if translation is missing in es', () => {
+    // This assumes some key is missing in es but present in en
+    // or we can test a non-existent key
+    initializeI18n('es')
+    const result = t('non.existent.key')
+    expect(result).toBe('non.existent.key')
+  })
+})

--- a/packages/core/src/commons/i18n.ts
+++ b/packages/core/src/commons/i18n.ts
@@ -16,7 +16,7 @@ function detectLanguage(): SupportedLanguage {
 
   // Node detection (for tests)
   if (typeof process !== 'undefined' && process.env) {
-    const envLang = process.env.LANG || process.env.LC_ALL || ''
+    const envLang = process.env.LC_ALL || process.env.LANG || ''
     const langCode = envLang.split(/[-_.]/)[0]?.toLowerCase()
 
     if (langCode && (SUPPORTED_LANGUAGES as readonly string[]).includes(langCode)) {

--- a/packages/core/src/commons/i18n.ts
+++ b/packages/core/src/commons/i18n.ts
@@ -1,0 +1,70 @@
+import i18next from 'i18next'
+import enMessages from './locales/en.json'
+import esMessages from './locales/es.json'
+
+const SUPPORTED_LANGUAGES = ['en', 'es'] as const
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number]
+
+function detectLanguage(): SupportedLanguage {
+  // Browser detection
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    const langCode = navigator.language.split('-')[0].toLowerCase()
+    if ((SUPPORTED_LANGUAGES as readonly string[]).includes(langCode)) {
+      return langCode as SupportedLanguage
+    }
+  }
+
+  // Node detection (for tests)
+  if (typeof process !== 'undefined' && process.env) {
+    const envLang = process.env.LANG || process.env.LC_ALL || ''
+    const langCode = envLang.split(/[-_.]/)[0]?.toLowerCase()
+
+    if (langCode && (SUPPORTED_LANGUAGES as readonly string[]).includes(langCode)) {
+      return langCode as SupportedLanguage
+    }
+  }
+
+  return 'en'
+}
+
+/**
+ * Initializes i18n support synchronously by providing resources directly.
+ */
+export function initializeI18n(language?: SupportedLanguage): void {
+  const detectedLanguage = language || detectLanguage()
+
+  if (i18next.isInitialized && !language) {
+    // If already initialized and no specific language requested, we might want to 
+    // change language if detection would result in a different one (mostly for tests)
+    if (i18next.language !== detectedLanguage) {
+      i18next.changeLanguage(detectedLanguage)
+    }
+    return
+  }
+
+  // We use the synchronous init by providing all resources upfront
+  i18next.init({
+    lng: detectedLanguage,
+    fallbackLng: 'en',
+    resources: {
+      en: { translation: enMessages },
+      es: { translation: esMessages },
+    },
+    interpolation: {
+      escapeValue: false, // Pelela handles its own sanitization
+    },
+    // This ensures initialization is as synchronous as possible
+    initImmediate: false,
+  })
+}
+
+export function t(key: string, options?: Record<string, unknown>): string {
+  return i18next.t(key, options)
+}
+
+export function getCurrentLanguage(): SupportedLanguage {
+  const current = i18next.language
+  return (SUPPORTED_LANGUAGES as readonly string[]).includes(current)
+    ? (current as SupportedLanguage)
+    : 'en'
+}

--- a/packages/core/src/commons/i18n.ts
+++ b/packages/core/src/commons/i18n.ts
@@ -79,3 +79,23 @@ export function getDecimalSeparator(): string {
   const parts = new Intl.NumberFormat(locale).formatToParts(numberWithDecimal)
   return parts.find((part) => part.type === 'decimal')?.value || '.'
 }
+
+/**
+ * Returns the thousands separator for the current language.
+ * Uses Intl.NumberFormat for robust detection.
+ */
+export function getThousandsSeparator(): string {
+  const locale = getCurrentLanguage()
+  const numberWithThousands = 1234567.89
+  const parts = new Intl.NumberFormat(locale, { useGrouping: true }).formatToParts(
+    numberWithThousands,
+  )
+  const groupPart = parts.find((part) => part.type === 'group')
+
+  if (groupPart) {
+    return groupPart.value
+  }
+
+  // Robust fallback: return the opposite of the decimal separator
+  return getDecimalSeparator() === ',' ? '.' : ','
+}

--- a/packages/core/src/commons/i18n.ts
+++ b/packages/core/src/commons/i18n.ts
@@ -68,3 +68,14 @@ export function getCurrentLanguage(): SupportedLanguage {
     ? (current as SupportedLanguage)
     : 'en'
 }
+
+/**
+ * Returns the decimal separator for the current language.
+ * Uses Intl.NumberFormat for robust detection.
+ */
+export function getDecimalSeparator(): string {
+  const locale = getCurrentLanguage()
+  const numberWithDecimal = 1.1
+  const parts = new Intl.NumberFormat(locale).formatToParts(numberWithDecimal)
+  return parts.find((part) => part.type === 'decimal')?.value || '.'
+}

--- a/packages/core/src/commons/i18n.ts
+++ b/packages/core/src/commons/i18n.ts
@@ -34,7 +34,7 @@ export function initializeI18n(language?: SupportedLanguage): void {
   const detectedLanguage = language || detectLanguage()
 
   if (i18next.isInitialized && !language) {
-    // If already initialized and no specific language requested, we might want to 
+    // If already initialized and no specific language requested, we might want to
     // change language if detection would result in a different one (mostly for tests)
     if (i18next.language !== detectedLanguage) {
       i18next.changeLanguage(detectedLanguage)

--- a/packages/core/src/commons/locales/en.json
+++ b/packages/core/src/commons/locales/en.json
@@ -10,7 +10,8 @@
       "invalidStructure": "[pelela] {{kind}}: Cannot setup binding, {{issue}}"
     },
     "handlers": {
-      "invalid": "[pelela] Handler \"{{name}}\" defined in {{eventInfo}} is not a function of view model \"{{viewModel}}\"."
+      "invalid": "[pelela] Handler \"{{name}}\" defined in {{eventInfo}} is not a function of view model \"{{viewModel}}\".",
+      "unknownEvent": "an event handler"
     },
     "properties": {
       "invalidType": "[pelela] Property \"{{name}}\" used in {{kind}} must be {{expected}}, but found different type on view model \"{{viewModel}}\". Element: {{snippet}}",

--- a/packages/core/src/commons/locales/en.json
+++ b/packages/core/src/commons/locales/en.json
@@ -22,6 +22,9 @@
         "duplicate": "[pelela] View model \"{{name}}\" is already registered",
         "missing": "[pelela] View model \"{{name}}\" is not registered. Did you call defineViewModel?"
       }
+    },
+    "security": {
+      "domEnvironmentRequired": "sanitizeHTML requires a DOM environment (document and DOMParser)"
     }
   }
 }

--- a/packages/core/src/commons/locales/en.json
+++ b/packages/core/src/commons/locales/en.json
@@ -1,0 +1,26 @@
+{
+  "errors": {
+    "bindings": {
+      "invalidSyntax": "[pelela] Invalid {{kind}} expression: \"{{expression}}\". Expected format: {{format}}",
+      "value": {
+        "invalidElement": "bind-value can only be used on input, textarea, or select elements. Found on <{{tagName}}>. Use bind-content for display elements.\nElement: {{snippet}}"
+      }
+    },
+    "dom": {
+      "invalidStructure": "[pelela] {{kind}}: Cannot setup binding, {{issue}}"
+    },
+    "handlers": {
+      "invalid": "[pelela] Handler \"{{name}}\" defined in {{eventInfo}} is not a function of view model \"{{viewModel}}\"."
+    },
+    "properties": {
+      "invalidType": "[pelela] Property \"{{name}}\" used in {{kind}} must be {{expected}}, but found different type on view model \"{{viewModel}}\". Element: {{snippet}}",
+      "validation": "[pelela] Unknown property \"{{name}}\" used in {{kind}} on: {{snippet}}. Make sure your view model \"{{viewModel}}\" defines it."
+    },
+    "viewmodel": {
+      "registration": {
+        "duplicate": "[pelela] View model \"{{name}}\" is already registered",
+        "missing": "[pelela] View model \"{{name}}\" is not registered. Did you call defineViewModel?"
+      }
+    }
+  }
+}

--- a/packages/core/src/commons/locales/es.json
+++ b/packages/core/src/commons/locales/es.json
@@ -1,0 +1,26 @@
+{
+  "errors": {
+    "bindings": {
+      "invalidSyntax": "[pelela] Expresión {{kind}} inválida: \"{{expression}}\". Formato esperado: {{format}}",
+      "value": {
+        "invalidElement": "bind-value solo puede usarse en elementos input, textarea o select. Se encontró en <{{tagName}}>. Usá bind-content para elementos de visualización.\nElemento: {{snippet}}"
+      }
+    },
+    "dom": {
+      "invalidStructure": "[pelela] {{kind}}: No se pudo configurar el binding, {{issue}}"
+    },
+    "handlers": {
+      "invalid": "[pelela] El handler \"{{name}}\" definido en {{eventInfo}} no es una función del view model \"{{viewModel}}\"."
+    },
+    "properties": {
+      "invalidType": "[pelela] La propiedad \"{{name}}\" usada en {{kind}} debe ser {{expected}}, pero se encontró un tipo diferente en el view model \"{{viewModel}}\". Elemento: {{snippet}}",
+      "validation": "[pelela] Propiedad desconocida \"{{name}}\" usada en {{kind}} en: {{snippet}}. Asegurate de que el view model \"{{viewModel}}\" la defina."
+    },
+    "viewmodel": {
+      "registration": {
+        "duplicate": "[pelela] El view model \"{{name}}\" ya está registrado",
+        "missing": "[pelela] El view model \"{{name}}\" no está registrado. ¿Llamaste a defineViewModel?"
+      }
+    }
+  }
+}

--- a/packages/core/src/commons/locales/es.json
+++ b/packages/core/src/commons/locales/es.json
@@ -22,6 +22,9 @@
         "duplicate": "[pelela] El view model \"{{name}}\" ya está registrado",
         "missing": "[pelela] El view model \"{{name}}\" no está registrado. ¿Llamaste a defineViewModel?"
       }
+    },
+    "security": {
+      "domEnvironmentRequired": "sanitizeHTML requiere un entorno DOM (document y DOMParser)"
     }
   }
 }

--- a/packages/core/src/commons/locales/es.json
+++ b/packages/core/src/commons/locales/es.json
@@ -10,7 +10,8 @@
       "invalidStructure": "[pelela] {{kind}}: No se pudo configurar el binding, {{issue}}"
     },
     "handlers": {
-      "invalid": "[pelela] El handler \"{{name}}\" definido en {{eventInfo}} no es una función del view model \"{{viewModel}}\"."
+      "invalid": "[pelela] El handler \"{{name}}\" definido en {{eventInfo}} no es una función del view model \"{{viewModel}}\".",
+      "unknownEvent": "un manejador de eventos"
     },
     "properties": {
       "invalidType": "[pelela] La propiedad \"{{name}}\" usada en {{kind}} debe ser {{expected}}, pero se encontró un tipo diferente en el view model \"{{viewModel}}\". Elemento: {{snippet}}",

--- a/packages/core/src/commons/sanitization.test.ts
+++ b/packages/core/src/commons/sanitization.test.ts
@@ -26,6 +26,12 @@ describe('sanitization', () => {
       expect(sanitize(input)).toEqual(expected)
     })
 
+    it('should preserve non-string values in arrays', () => {
+      const input = ['<script>', 42, true, null]
+      const expected = ['&lt;script&gt;', 42, true, null]
+      expect(sanitize(input)).toEqual(expected)
+    })
+
     it('should sanitize nested objects', () => {
       const input = {
         name: '<script>',

--- a/packages/core/src/commons/sanitization.test.ts
+++ b/packages/core/src/commons/sanitization.test.ts
@@ -58,5 +58,11 @@ describe('sanitization', () => {
       expect(sanitize(null)).toBe(null)
       expect(sanitize(undefined)).toBe(undefined)
     })
+
+    it('should fail fast on circular references', () => {
+      const input: Record<string, unknown> = {}
+      input.self = input
+      expect(() => sanitize(input)).toThrow(/circular/i)
+    })
   })
 })

--- a/packages/core/src/commons/sanitization.test.ts
+++ b/packages/core/src/commons/sanitization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { escapeHTML, sanitize } from './sanitization'
+import { escapeHTML, sanitize, sanitizeHTML } from './sanitization'
 
 describe('sanitization', () => {
   describe('escapeHTML', () => {
@@ -63,6 +63,34 @@ describe('sanitization', () => {
       const input: Record<string, unknown> = {}
       input.self = input
       expect(() => sanitize(input)).toThrow(/circular/i)
+    })
+  })
+
+  describe('sanitizeHTML', () => {
+    it('should strip malicious tags and attributes', () => {
+      const input =
+        '<div>Safe</div><script>alert(1)</script><button onclick="alert(2)">Click</button>'
+      const output = sanitizeHTML(input)
+      expect(output).toContain('<div>Safe</div>')
+      expect(output).not.toContain('<script>')
+      expect(output).not.toContain('onclick')
+    })
+
+    it('should throw error when DOM environment is missing', () => {
+      const originalDocument = global.document
+      const originalDOMParser = global.DOMParser
+
+      try {
+        // @ts-expect-error - simulating environment without DOM
+        global.document = undefined
+        // @ts-expect-error - simulating environment without DOM
+        global.DOMParser = undefined
+
+        expect(() => sanitizeHTML('<div></div>')).toThrow(/DOM environment/i)
+      } finally {
+        global.document = originalDocument
+        global.DOMParser = originalDOMParser
+      }
     })
   })
 })

--- a/packages/core/src/commons/sanitization.test.ts
+++ b/packages/core/src/commons/sanitization.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { escapeHTML, sanitize } from './sanitization'
+
+describe('sanitization', () => {
+  describe('escapeHTML', () => {
+    it('should escape special characters', () => {
+      expect(escapeHTML('<script>alert("XSS")</script>')).toBe(
+        '&lt;script&gt;alert(&quot;XSS&quot;)&lt;&#x2F;script&gt;',
+      )
+      expect(escapeHTML('& " \' /')).toBe('&amp; &quot; &#39; &#x2F;')
+    })
+
+    it('should return empty string for empty input', () => {
+      expect(escapeHTML('')).toBe('')
+    })
+  })
+
+  describe('sanitize', () => {
+    it('should sanitize strings', () => {
+      expect(sanitize('<b>Bold</b>')).toBe('&lt;b&gt;Bold&lt;&#x2F;b&gt;')
+    })
+
+    it('should sanitize arrays', () => {
+      const input = ['<script>', 'safe']
+      const expected = ['&lt;script&gt;', 'safe']
+      expect(sanitize(input)).toEqual(expected)
+    })
+
+    it('should sanitize nested objects', () => {
+      const input = {
+        name: '<script>',
+        info: {
+          bio: '<b>',
+        },
+      }
+      const expected = {
+        name: '&lt;script&gt;',
+        info: {
+          bio: '&lt;b&gt;',
+        },
+      }
+      expect(sanitize(input)).toEqual(expected)
+    })
+
+    it('should preserve numbers and booleans', () => {
+      expect(sanitize(123)).toBe(123)
+      expect(sanitize(true)).toBe(true)
+      expect(sanitize(false)).toBe(false)
+    })
+
+    it('should handle null and undefined', () => {
+      expect(sanitize(null)).toBe(null)
+      expect(sanitize(undefined)).toBe(undefined)
+    })
+  })
+})

--- a/packages/core/src/commons/sanitization.ts
+++ b/packages/core/src/commons/sanitization.ts
@@ -22,6 +22,8 @@ export function escapeHTML(text: string): string {
 /**
  * Sanitizes any value. If it's a string, it's escaped.
  * If it's an object/array, it recurses (safely).
+ * Note: For objects, returns a plain object without preserving the prototype.
+ * Class instances will lose their methods.
  */
 export function sanitize<T>(value: T): T {
   if (typeof value === 'string') {

--- a/packages/core/src/commons/sanitization.ts
+++ b/packages/core/src/commons/sanitization.ts
@@ -48,3 +48,65 @@ function sanitizeInternal(value: unknown, seen: WeakSet<object>): unknown {
   })
   return result
 }
+
+/**
+ * XSS Security Rules
+ */
+const DANGEROUS_TAGS = new Set(['SCRIPT', 'IFRAME', 'OBJECT', 'EMBED', 'BASE', 'STYLE'])
+
+type TagRule = (tagName: string) => boolean
+type AttributeRule = (name: string, value: string) => boolean
+
+const TAG_RULES: TagRule[] = [(tagName) => DANGEROUS_TAGS.has(tagName)]
+
+const ATTRIBUTE_RULES: AttributeRule[] = [
+  (name) => name.startsWith('on'),
+  (name, value) =>
+    (name === 'href' || name === 'src') && value.toLowerCase().startsWith('javascript:'),
+]
+
+function isUnsafeTag(tagName: string): boolean {
+  return TAG_RULES.some((rule) => rule(tagName))
+}
+
+function isUnsafeAttribute(name: string, value: string): boolean {
+  return ATTRIBUTE_RULES.some((rule) => rule(name, value))
+}
+
+/**
+ * Sanitizes an HTML string by removing dangerous elements and attributes
+ * (like <script> and onclick) while preserving the overall structure.
+ * Useful for templates.
+ */
+export function sanitizeHTML(html: string): string {
+  if (typeof document === 'undefined') return html // Fallback for environments without DOM
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+  const body = doc.body
+
+  function walk(node: Node) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const element = node as HTMLElement
+
+      if (isUnsafeTag(element.tagName)) {
+        element.remove()
+        return
+      }
+
+      Array.from(element.attributes).forEach((attr) => {
+        if (isUnsafeAttribute(attr.name, attr.value)) {
+          element.removeAttribute(attr.name)
+        }
+      })
+    }
+
+    Array.from(node.childNodes).forEach((child) => {
+      walk(child)
+    })
+  }
+
+  walk(body)
+
+  return body.innerHTML
+}

--- a/packages/core/src/commons/sanitization.ts
+++ b/packages/core/src/commons/sanitization.ts
@@ -1,3 +1,5 @@
+import { t } from './i18n'
+
 /**
  * Utilities for sanitizing and escaping untrusted content
  * before injecting it into the DOM or other sensitive contexts
@@ -79,7 +81,9 @@ function isUnsafeAttribute(name: string, value: string): boolean {
  * Useful for templates.
  */
 export function sanitizeHTML(html: string): string {
-  if (typeof document === 'undefined') return html // Fallback for environments without DOM
+  if (typeof document === 'undefined' || typeof DOMParser === 'undefined') {
+    throw new Error(t('errors.security.domEnvironmentRequired'))
+  }
 
   const parser = new DOMParser()
   const doc = parser.parseFromString(html, 'text/html')

--- a/packages/core/src/commons/sanitization.ts
+++ b/packages/core/src/commons/sanitization.ts
@@ -1,0 +1,45 @@
+/**
+ * Utility for sanitizing strings to prevent XSS and other injection attacks.
+ * Follows OWASP recommendations for basic HTML escaping.
+ */
+
+/**
+ * Escapes HTML special characters in a string.
+ */
+export function escapeHTML(text: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+  }
+
+  return text.replace(/[&<>"'/]/g, (character) => map[character])
+}
+
+/**
+ * Sanitizes any value. If it's a string, it's escaped.
+ * If it's an object/array, it recurses (safely).
+ */
+export function sanitize<T>(value: T): T {
+  if (typeof value === 'string') {
+    return escapeHTML(value) as unknown as T
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitize(item)) as unknown as T
+  }
+
+  const result = {} as Record<string, unknown>
+  Object.entries(value).forEach(([key, val]) => {
+    result[key] = sanitize(val)
+  })
+
+  return result as unknown as T
+}

--- a/packages/core/src/commons/sanitization.ts
+++ b/packages/core/src/commons/sanitization.ts
@@ -1,6 +1,6 @@
 /**
- * Utility for sanitizing strings to prevent XSS and other injection attacks.
- * Follows OWASP recommendations for basic HTML escaping.
+ * Utilities for sanitizing and escaping untrusted content
+ * before injecting it into the DOM or other sensitive contexts
  */
 
 /**
@@ -26,22 +26,25 @@ export function escapeHTML(text: string): string {
  * Class instances will lose their methods.
  */
 export function sanitize<T>(value: T): T {
-  if (typeof value === 'string') {
-    return escapeHTML(value) as unknown as T
-  }
+  return sanitizeInternal(value, new WeakSet()) as T
+}
 
-  if (value === null || typeof value !== 'object') {
-    return value
+function sanitizeInternal(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') return escapeHTML(value)
+  if (value === null || typeof value !== 'object') return value
+
+  if (seen.has(value)) {
+    throw new TypeError('Cannot sanitize circular references')
   }
+  seen.add(value)
 
   if (Array.isArray(value)) {
-    return value.map((item) => sanitize(item)) as unknown as T
+    return value.map((item) => sanitizeInternal(item, seen))
   }
 
   const result = {} as Record<string, unknown>
   Object.entries(value).forEach(([key, val]) => {
-    result[key] = sanitize(val)
+    result[key] = sanitizeInternal(val, seen)
   })
-
-  return result as unknown as T
+  return result
 }

--- a/packages/core/src/errors/InvalidBindingSyntaxError.ts
+++ b/packages/core/src/errors/InvalidBindingSyntaxError.ts
@@ -1,3 +1,4 @@
+import { t } from '../commons/i18n'
 import type { BindingKind } from '.'
 import { PelelaError } from './PelelaError'
 
@@ -9,7 +10,11 @@ export class InvalidBindingSyntaxError extends PelelaError {
     options?: ErrorOptions,
   ) {
     super(
-      `[pelela] Invalid ${bindingKind} expression: "${expression}". Expected format: ${expectedFormat}`,
+      t('errors.bindings.invalidSyntax', {
+        kind: bindingKind,
+        expression,
+        format: expectedFormat,
+      }),
       options,
     )
   }

--- a/packages/core/src/errors/InvalidDOMStructureError.ts
+++ b/packages/core/src/errors/InvalidDOMStructureError.ts
@@ -1,3 +1,4 @@
+import { t } from '../commons/i18n'
 import type { BindingKind } from '.'
 import { PelelaError } from './PelelaError'
 
@@ -7,6 +8,12 @@ export class InvalidDOMStructureError extends PelelaError {
     public readonly issue: string,
     options?: ErrorOptions,
   ) {
-    super(`[pelela] ${bindingKind}: Cannot setup binding, ${issue}`, options)
+    super(
+      t('errors.dom.invalidStructure', {
+        kind: bindingKind,
+        issue,
+      }),
+      options,
+    )
   }
 }

--- a/packages/core/src/errors/InvalidHandlerError.ts
+++ b/packages/core/src/errors/InvalidHandlerError.ts
@@ -10,7 +10,7 @@ export class InvalidHandlerError extends PelelaError {
     public readonly eventType?: EventType,
     options?: ErrorOptions,
   ) {
-    const eventInfo = eventType ? `${eventType}="..."` : 'an event handler'
+    const eventInfo = eventType ? `${eventType}="..."` : t('errors.handlers.unknownEvent')
     super(
       t('errors.handlers.invalid', {
         name: handlerName,

--- a/packages/core/src/errors/InvalidHandlerError.ts
+++ b/packages/core/src/errors/InvalidHandlerError.ts
@@ -1,3 +1,4 @@
+import { t } from '../commons/i18n'
 import { PelelaError } from './PelelaError'
 
 export type EventType = 'click' | 'submit' | 'change' | 'input' | 'keypress' | (string & {})
@@ -11,8 +12,11 @@ export class InvalidHandlerError extends PelelaError {
   ) {
     const eventInfo = eventType ? `${eventType}="..."` : 'an event handler'
     super(
-      `[pelela] Handler "${handlerName}" defined in ${eventInfo} is not a function ` +
-        `of view model "${viewModelName}".`,
+      t('errors.handlers.invalid', {
+        name: handlerName,
+        eventInfo,
+        viewModel: viewModelName,
+      }),
       options,
     )
   }

--- a/packages/core/src/errors/InvalidPropertyTypeError.ts
+++ b/packages/core/src/errors/InvalidPropertyTypeError.ts
@@ -1,3 +1,4 @@
+import { t } from '../commons/i18n'
 import type { BindingKind } from '.'
 import { PelelaError } from './PelelaError'
 
@@ -21,8 +22,13 @@ export class InvalidPropertyTypeError extends PelelaError {
 
   constructor(params: InvalidPropertyTypeErrorParams) {
     super(
-      `[pelela] Property "${params.propertyName}" used in ${params.bindingKind} must be ${params.expectedType}, ` +
-        `but found different type on view model "${params.viewModelName}". Element: ${params.elementSnippet}`,
+      t('errors.properties.invalidType', {
+        name: params.propertyName,
+        kind: params.bindingKind,
+        expected: params.expectedType,
+        viewModel: params.viewModelName,
+        snippet: params.elementSnippet,
+      }),
       params.options,
     )
 

--- a/packages/core/src/errors/PropertyValidationError.ts
+++ b/packages/core/src/errors/PropertyValidationError.ts
@@ -1,3 +1,4 @@
+import { t } from '../commons/i18n'
 import { PelelaError } from './PelelaError'
 
 export type BindingKind =
@@ -24,8 +25,12 @@ export class PropertyValidationError extends PelelaError {
 
   constructor(params: PropertyValidationErrorParams) {
     super(
-      `[pelela] Unknown property "${params.propertyName}" used in ${params.bindingKind} on: ${params.elementSnippet}. ` +
-        `Make sure your view model "${params.viewModelName}" defines it.`,
+      t('errors.properties.validation', {
+        name: params.propertyName,
+        kind: params.bindingKind,
+        snippet: params.elementSnippet,
+        viewModel: params.viewModelName,
+      }),
       params.options,
     )
 

--- a/packages/core/src/errors/ViewModelRegistrationError.ts
+++ b/packages/core/src/errors/ViewModelRegistrationError.ts
@@ -1,12 +1,7 @@
+import { t } from '../commons/i18n'
 import { PelelaError } from './PelelaError'
 
 export type RegistrationType = 'duplicate' | 'missing'
-
-const REGISTRATION_ERROR_MESSAGES: Record<RegistrationType, (viewModelName: string) => string> = {
-  duplicate: (name) => `[pelela] View model "${name}" is already registered`,
-  missing: (name) =>
-    `[pelela] View model "${name}" is not registered. Did you call defineViewModel?`,
-}
 
 export class ViewModelRegistrationError extends PelelaError {
   constructor(
@@ -14,6 +9,11 @@ export class ViewModelRegistrationError extends PelelaError {
     public readonly type: RegistrationType,
     options?: ErrorOptions,
   ) {
-    super(REGISTRATION_ERROR_MESSAGES[type](viewModelName), options)
+    super(
+      t(`errors.viewmodel.registration.${type}`, {
+        name: viewModelName,
+      }),
+      options,
+    )
   }
 }

--- a/packages/core/src/reactivity/reactiveProxy.test.ts
+++ b/packages/core/src/reactivity/reactiveProxy.test.ts
@@ -36,7 +36,7 @@ describe('reactiveProxy', () => {
     })
 
     it('should allow adding new properties', () => {
-      const target: any = { count: 0 }
+      const target: Record<string, unknown> = { count: 0 }
       const onChange = vi.fn()
       const proxy = createReactiveViewModel(target, onChange)
 
@@ -214,7 +214,7 @@ describe('reactiveProxy', () => {
     })
 
     it('should handle property deletion', () => {
-      const target: any = { a: 1, b: 2 }
+      const target: Record<string, unknown> = { a: 1, b: 2 }
       const onChange = vi.fn()
       const proxy = createReactiveViewModel(target, onChange)
 
@@ -222,11 +222,11 @@ describe('reactiveProxy', () => {
 
       expect(onChange).toHaveBeenCalled()
       expect(proxy.b).toBeUndefined()
-      expect('b' in proxy).toBe(false)
+      expect('b' in (proxy as object)).toBe(false)
     })
 
     it('should handle circular references without stack overflow', () => {
-      const target: any = { name: 'root' }
+      const target: Record<string, unknown> = { name: 'root' }
       target.self = target
 
       const onChange = vi.fn()
@@ -254,7 +254,7 @@ describe('reactiveProxy', () => {
     })
 
     it('should handle $set helper method', () => {
-      const target: any = { items: ['a', 'b', 'c'] }
+      const target: Record<string, unknown> = { items: ['a', 'b', 'c'] }
       const onChange = vi.fn()
       const proxy = createReactiveViewModel(target, onChange)
 
@@ -265,7 +265,7 @@ describe('reactiveProxy', () => {
     })
 
     it('should handle $delete helper method', () => {
-      const target: any = { a: 1, b: 2 }
+      const target: Record<string, unknown> = { a: 1, b: 2 }
       const onChange = vi.fn()
       const proxy = createReactiveViewModel(target, onChange)
 
@@ -299,7 +299,7 @@ describe('reactiveProxy', () => {
 
     it('should use full path when notifying changes of properties in assigned objects', () => {
       const onChange = vi.fn()
-      const proxy = createReactiveViewModel({ address: {} as any }, onChange)
+      const proxy = createReactiveViewModel({ address: {} as Record<string, unknown> }, onChange)
 
       proxy.address = { city: 'New York' }
       expect(onChange).toHaveBeenCalledWith('address')
@@ -311,7 +311,7 @@ describe('reactiveProxy', () => {
 
     it('should use full path when using $set helper for nested objects', () => {
       const onChange = vi.fn()
-      const proxy = createReactiveViewModel({ user: {} as any }, onChange)
+      const proxy = createReactiveViewModel({ user: {} as Record<string, unknown> }, onChange)
 
       proxy.$set(proxy.user, 'profile', { bio: 'Hello' })
       expect(onChange).toHaveBeenCalledWith('user.profile')
@@ -334,7 +334,7 @@ describe('reactiveProxy', () => {
       const target = {}
       Object.defineProperty(target, 'a', { value: 1, configurable: false })
       const onChange = vi.fn()
-      const proxy = createReactiveViewModel(target as any, onChange)
+      const proxy = createReactiveViewModel(target as Record<string, unknown>, onChange)
 
       proxy.$delete(proxy, 'a')
       expect(onChange).not.toHaveBeenCalled()
@@ -372,7 +372,7 @@ describe('reactiveProxy', () => {
 
     it('should implement lazy reactivity: objects are made reactive on access, not on assignment', () => {
       const onChange = vi.fn()
-      const proxy = createReactiveViewModel({ data: {} as any }, onChange)
+      const proxy = createReactiveViewModel({ data: {} as Record<string, unknown> }, onChange)
       const rawObject = { city: 'New York' }
 
       proxy.data = rawObject

--- a/packages/core/src/reactivity/reactiveProxy.test.ts
+++ b/packages/core/src/reactivity/reactiveProxy.test.ts
@@ -254,7 +254,7 @@ describe('reactiveProxy', () => {
     })
 
     it('should handle $set helper method', () => {
-      const target: Record<string, unknown> = { items: ['a', 'b', 'c'] }
+      const target = { items: ['a', 'b', 'c'] }
       const onChange = vi.fn()
       const proxy = createReactiveViewModel(target, onChange)
 
@@ -313,11 +313,12 @@ describe('reactiveProxy', () => {
       const onChange = vi.fn()
       const proxy = createReactiveViewModel({ user: {} as Record<string, unknown> }, onChange)
 
-      proxy.$set(proxy.user, 'profile', { bio: 'Hello' })
+      proxy.$set(proxy.user as object, 'profile', { bio: 'Hello' })
       expect(onChange).toHaveBeenCalledWith('user.profile')
       onChange.mockClear()
 
-      proxy.user.profile.bio = 'Hi'
+      // Access nested property added via $set
+      ;(proxy.user as Record<string, Record<string, string>>).profile.bio = 'Hi'
       expect(onChange).toHaveBeenCalledWith('user.profile.bio')
     })
 

--- a/packages/core/src/validation/assertViewModelProperty.test.ts
+++ b/packages/core/src/validation/assertViewModelProperty.test.ts
@@ -73,8 +73,8 @@ describe('assertViewModelProperty', () => {
 
     try {
       assertViewModelProperty(viewModel, 'missing', 'bind-value', element)
-    } catch (error: any) {
-      expect(error.message.length).toBeLessThan(300)
+    } catch (error: unknown) {
+      expect((error as Error).message.length).toBeLessThan(300)
     }
   })
 
@@ -126,7 +126,7 @@ describe('assertViewModelProperty', () => {
   })
 
   it('should throw error if intermediate property is null', () => {
-    const viewModel = { user: null as any }
+    const viewModel = { user: null as unknown as object }
     const element = document.createElement('div')
 
     expect(() => {

--- a/packages/core/src/validation/assertViewModelProperty.test.ts
+++ b/packages/core/src/validation/assertViewModelProperty.test.ts
@@ -122,7 +122,7 @@ describe('assertViewModelProperty', () => {
 
     expect(() => {
       assertViewModelProperty(viewModel, 'user.missing', 'bind-value', element)
-    }).toThrow('[pelela] Unknown property "user.missing"')
+    }).toThrow(/Unknown property "user.missing"/)
   })
 
   it('should throw error if intermediate property is null', () => {
@@ -131,7 +131,7 @@ describe('assertViewModelProperty', () => {
 
     expect(() => {
       assertViewModelProperty(viewModel, 'user.name', 'bind-value', element)
-    }).toThrow('[pelela] Unknown property "user.name"')
+    }).toThrow(/Unknown property "user.name"/)
   })
 
   it('should not use fast path for dotted properties that exist as literal keys: eg. "user.name" when user does not exist', () => {
@@ -140,6 +140,6 @@ describe('assertViewModelProperty', () => {
 
     expect(() => {
       assertViewModelProperty(viewModel, 'user.name', 'bind-value', element)
-    }).toThrow('[pelela] Unknown property "user.name"')
+    }).toThrow(/Unknown property "user.name"/)
   })
 })

--- a/packages/core/src/validation/assertViewModelProperty.ts
+++ b/packages/core/src/validation/assertViewModelProperty.ts
@@ -1,4 +1,5 @@
 import { isObject } from '../commons/helpers'
+import { sanitize } from '../commons/sanitization'
 import { type BindingKind, PropertyValidationError } from '../errors'
 
 function hasNestedProperty(targetObject: unknown, path: string): boolean {
@@ -39,7 +40,9 @@ export function assertViewModelProperty<T extends object>(
   element: Element,
 ): void {
   if (!hasNestedProperty(viewModel, propertyName)) {
-    const elementSnippet = element.outerHTML.replace(/\s+/g, ' ').trim().slice(0, 100)
+    const elementSnippet = sanitize(
+      element.outerHTML.replace(/\s+/g, ' ').trim().slice(0, 100),
+    ) as string
 
     throw new PropertyValidationError({
       propertyName,

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -1,0 +1,5 @@
+import { initializeI18n } from './src/commons/i18n'
+
+// Initialize i18n once for all tests to ensure t() works in unit tests
+// isolated from bootstrap().
+initializeI18n('en')

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -1,5 +1,7 @@
+import { beforeEach } from 'vitest'
 import { initializeI18n } from './src/commons/i18n'
 
-// Initialize i18n once for all tests to ensure t() works in unit tests
-// isolated from bootstrap().
-initializeI18n('en')
+// Ensure deterministic locale for every test case.
+beforeEach(() => {
+  initializeI18n('en')
+})

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineProject({
   test: {
     name: 'core',
     environment: 'jsdom',
+    setupFiles: ['./test-setup.ts'],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,10 @@ importers:
         version: 7.2.4(@types/node@24.10.1)(tsx@4.21.0)
 
   packages/core:
+    dependencies:
+      i18next:
+        specifier: ^23.7.6
+        version: 23.16.8
     devDependencies:
       '@types/node':
         specifier: 24.10.1
@@ -222,6 +226,10 @@ packages:
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
@@ -1496,6 +1504,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  i18next@23.16.8:
+    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -2660,6 +2671,8 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/types@7.28.5':
     dependencies:
@@ -3848,6 +3861,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  i18next@23.16.8:
+    dependencies:
+      '@babel/runtime': 7.29.2
 
   iconv-lite@0.6.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1565,6 +1565,9 @@ packages:
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
 
+  i18next@23.7.6:
+    resolution: {integrity: sha512-O66BhXBw0fH4bEJMA0/klQKPEbcwAp5wjXEL803pdAynNbg2f4qhLIYlNHJyE7icrL6XmSZKPYaaXwy11kJ6YQ==}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -3959,6 +3962,10 @@ snapshots:
       - supports-color
 
   i18next@23.16.8:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  i18next@23.7.6:
     dependencies:
       '@babel/runtime': 7.29.2
 


### PR DESCRIPTION
Aproveché para meter

- i18n a los mensajes de usuario (por ahora no al console.log/console.warn) (#65)
- refactors que quedaron pendientes: variables de una sola letra, uso de any, código no declarativo
- también le pedí que evite XSS e inyecciones de código JS (#67)
- y de paso, encontré que el bindValue hacía un replace a manopla, es preferible basarnos en el Locale para manipular números