### PR TITLE
Fixes para el release npm y el CLI standalone

### DIFF
--- a/scripts/release-npm.ts
+++ b/scripts/release-npm.ts
@@ -41,8 +41,25 @@ const runCommand = (command: string, description: string, cwd?: string): void =>
   }
 }
 
-const readRootPackageJson = (): RootPackageJson =>
-  JSON.parse(readFileSync(rootPackageJsonPath, 'utf-8')) as RootPackageJson
+const readRootPackageJson = (): RootPackageJson => {
+  const parsed = JSON.parse(readFileSync(rootPackageJsonPath, 'utf-8')) as {
+    engines?: { node?: unknown }
+    version?: unknown
+  }
+
+  if (typeof parsed.engines?.node !== 'string') {
+    throw new Error('Missing engines.node in root package.json')
+  }
+
+  if (typeof parsed.version !== 'string') {
+    throw new Error('Missing version in root package.json')
+  }
+
+  return {
+    engines: { node: parsed.engines.node },
+    version: parsed.version,
+  }
+}
 
 const validateEnvironment = (): void => {
   const nodeVersion = process.version

--- a/scripts/release-npm.ts
+++ b/scripts/release-npm.ts
@@ -6,7 +6,6 @@ import readline from 'node:readline/promises'
 import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
 import semver from 'semver'
-import { getRequiredNodeVersion } from '../tools/pelela-cli/src/utils/nodeVersion'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -14,6 +13,11 @@ const rootPackageJsonPath = resolve(__dirname, '..', 'package.json')
 
 const VALID_VERSION_TYPES = ['patch', 'minor', 'major'] as const
 type VersionType = (typeof VALID_VERSION_TYPES)[number]
+
+interface RootPackageJson {
+  engines: { node: string }
+  version: string
+}
 
 const isValidVersionType = (value: string): value is VersionType =>
   (VALID_VERSION_TYPES as readonly string[]).includes(value)
@@ -37,9 +41,12 @@ const runCommand = (command: string, description: string, cwd?: string): void =>
   }
 }
 
+const readRootPackageJson = (): RootPackageJson =>
+  JSON.parse(readFileSync(rootPackageJsonPath, 'utf-8')) as RootPackageJson
+
 const validateEnvironment = (): void => {
   const nodeVersion = process.version
-  const requiredNodeVersion = getRequiredNodeVersion()
+  const requiredNodeVersion = readRootPackageJson().engines.node
   if (!semver.satisfies(nodeVersion, requiredNodeVersion)) {
     console.error(
       chalk.red(`\n❌ PelelaJS requires Node.js ${requiredNodeVersion}. Current: ${nodeVersion}`),
@@ -148,7 +155,7 @@ const main = async (): Promise<void> => {
   )
 
   // 5. Git Commit, Tag and Push
-  const newVersion = JSON.parse(readFileSync(rootPackageJsonPath, 'utf-8')).version
+  const newVersion = readRootPackageJson().version
 
   runCommand('git add .', 'Staging changes')
   runCommand(

--- a/scripts/release-npm.ts
+++ b/scripts/release-npm.ts
@@ -6,9 +6,11 @@ import readline from 'node:readline/promises'
 import { fileURLToPath } from 'node:url'
 import chalk from 'chalk'
 import semver from 'semver'
+import { getRequiredNodeVersion } from '../tools/pelela-cli/src/utils/nodeVersion'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
+const rootPackageJsonPath = resolve(__dirname, '..', 'package.json')
 
 const VALID_VERSION_TYPES = ['patch', 'minor', 'major'] as const
 type VersionType = (typeof VALID_VERSION_TYPES)[number]
@@ -37,10 +39,10 @@ const runCommand = (command: string, description: string, cwd?: string): void =>
 
 const validateEnvironment = (): void => {
   const nodeVersion = process.version
-  const requiredVersion = '>=22.0.0'
-  if (!semver.satisfies(nodeVersion, requiredVersion)) {
+  const requiredNodeVersion = getRequiredNodeVersion()
+  if (!semver.satisfies(nodeVersion, requiredNodeVersion)) {
     console.error(
-      chalk.red(`\n❌ PelelaJS requires Node.js ${requiredVersion}. Current: ${nodeVersion}`),
+      chalk.red(`\n❌ PelelaJS requires Node.js ${requiredNodeVersion}. Current: ${nodeVersion}`),
     )
     process.exit(1)
   }
@@ -146,9 +148,7 @@ const main = async (): Promise<void> => {
   )
 
   // 5. Git Commit, Tag and Push
-  const newVersion = JSON.parse(
-    readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'),
-  ).version
+  const newVersion = JSON.parse(readFileSync(rootPackageJsonPath, 'utf-8')).version
 
   runCommand('git add .', 'Staging changes')
   runCommand(

--- a/tools/pelela-cli/src/index.ts
+++ b/tools/pelela-cli/src/index.ts
@@ -3,14 +3,15 @@ import { Command } from 'commander'
 import semver from 'semver'
 import { initCommand } from './commands/init'
 import { initializeI18n, t } from './utils/i18n'
+import { getRequiredNodeVersion } from './utils/nodeVersion'
 import { checkNewVersion, getCliVersion } from './utils/version'
 
 const { log, warn } = console
 
 function validateNodeVersion(): void {
-  const requiredVersion = '>=22.0.0'
-  if (!semver.satisfies(process.version, requiredVersion)) {
-    warn(chalk.red.bold(`\n${t('errors.nodeVersion', { requiredVersion })}\n`))
+  const requiredNodeVersion = getRequiredNodeVersion()
+  if (!semver.satisfies(process.version, requiredNodeVersion)) {
+    warn(chalk.red.bold(`\n${t('errors.nodeVersion', { requiredVersion: requiredNodeVersion })}\n`))
     warn(chalk.red(`${t('errors.currentVersion', { currentVersion: process.version })}\n`))
     process.exit(1)
   }

--- a/tools/pelela-cli/src/locales/en.json
+++ b/tools/pelela-cli/src/locales/en.json
@@ -26,7 +26,7 @@
     "install": "pnpm install",
     "dev": "pnpm dev",
     "newVersionAvailable": "🆕 A new version is available: {{version}}",
-    "updateCommand": "Run `pnpm add -g @pelelajs/cli` to update",
+    "updateCommand": "Run `pnpm add -g pelelajs` to update",
     "versionCheckFailed": "Failed to check for updates: {{error}}"
   },
   "errors": {

--- a/tools/pelela-cli/src/locales/es.json
+++ b/tools/pelela-cli/src/locales/es.json
@@ -26,7 +26,7 @@
     "install": "pnpm install",
     "dev": "pnpm dev",
     "newVersionAvailable": "🆕 Una nueva versión está disponible: {{version}}",
-    "updateCommand": "Ejecuta `pnpm add -g @pelelajs/cli` para actualizar",
+    "updateCommand": "Ejecuta `pnpm add -g pelelajs` para actualizar",
     "versionCheckFailed": "Error al verificar actualizaciones: {{error}}"
   },
   "errors": {

--- a/tools/pelela-cli/src/utils/modulePath.ts
+++ b/tools/pelela-cli/src/utils/modulePath.ts
@@ -1,0 +1,6 @@
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function getCurrentModuleDir(importMetaUrl: string): string {
+  return typeof __dirname === 'undefined' ? dirname(fileURLToPath(importMetaUrl)) : __dirname
+}

--- a/tools/pelela-cli/src/utils/nodeVersion.ts
+++ b/tools/pelela-cli/src/utils/nodeVersion.ts
@@ -1,5 +1,5 @@
-import rootPackageJson from '../../../../package.json' with { type: 'json' }
+import cliPackageJson from '../../package.json' with { type: 'json' }
 
 export function getRequiredNodeVersion(): string {
-  return rootPackageJson.engines.node
+  return cliPackageJson.engines.node
 }

--- a/tools/pelela-cli/src/utils/nodeVersion.ts
+++ b/tools/pelela-cli/src/utils/nodeVersion.ts
@@ -1,0 +1,5 @@
+import rootPackageJson from '../../../../package.json' with { type: 'json' }
+
+export function getRequiredNodeVersion(): string {
+  return rootPackageJson.engines.node
+}

--- a/tools/pelela-cli/src/utils/templates.ts
+++ b/tools/pelela-cli/src/utils/templates.ts
@@ -10,7 +10,10 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 import { t } from './i18n'
+import { getCurrentModuleDir } from './modulePath'
 import { createDirectory } from './shell'
+
+export const BASE_TEMPLATE_FOR_CLI = 'base-template-for-cli'
 
 /**
  * Recursively copy a directory.
@@ -37,12 +40,13 @@ export function computeTemplatePath(currentDir: string): string {
   // In development (currentDir is src/utils), template is in ../../templates
   // In production (currentDir is dist), template is at the same level (via tsup's publicDir)
   return currentDir.includes('dist')
-    ? join(currentDir, 'base-template-for-cli')
-    : join(currentDir, '..', '..', 'templates', 'base-template-for-cli')
+    ? join(currentDir, BASE_TEMPLATE_FOR_CLI)
+    : join(currentDir, '..', '..', 'templates', BASE_TEMPLATE_FOR_CLI)
 }
 
-// In CJS bundled by tsup, __dirname is available globally
-const TEMPLATE_SOURCE = computeTemplatePath(__dirname)
+const currentModuleDir = getCurrentModuleDir(import.meta.url)
+
+const TEMPLATE_SOURCE = computeTemplatePath(currentModuleDir)
 
 export function copyTemplate(projectPath: string): void {
   if (!existsSync(TEMPLATE_SOURCE)) {

--- a/tools/pelela-cli/src/utils/version.ts
+++ b/tools/pelela-cli/src/utils/version.ts
@@ -1,11 +1,18 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { gt } from 'semver'
+import { getCurrentModuleDir } from './modulePath'
 
 interface PackageInfo {
   name: string
   version: string
 }
+
+const supportedCliPackages = ['pelelajs', '@pelelajs/cli'] as const
+
+type SupportedCliPackage = (typeof supportedCliPackages)[number]
+
+const currentModuleDir = getCurrentModuleDir(import.meta.url)
 
 const findVersionRecursively = (currentDir: string, depth: number): string => {
   if (depth <= 0) {
@@ -18,7 +25,7 @@ const findVersionRecursively = (currentDir: string, depth: number): string => {
     const content = readFileSync(pkgPath, 'utf-8')
     const pkg = JSON.parse(content) as PackageInfo
 
-    return ['pelelajs', '@pelelajs/cli', 'vite-plugin-pelelajs'].includes(pkg.name)
+    return supportedCliPackages.includes(pkg.name as SupportedCliPackage)
       ? pkg.version
       : findVersionRecursively(dirname(currentDir), depth - 1)
   } catch (_error) {
@@ -27,7 +34,7 @@ const findVersionRecursively = (currentDir: string, depth: number): string => {
 }
 
 function getPackageVersion(): string {
-  return findVersionRecursively(__dirname, 5)
+  return findVersionRecursively(currentModuleDir, 5)
 }
 
 export function getCliVersion(): string {

--- a/tools/pelela-cli/src/utils/version.ts
+++ b/tools/pelela-cli/src/utils/version.ts
@@ -14,6 +14,10 @@ type SupportedCliPackage = (typeof supportedCliPackages)[number]
 
 const currentModuleDir = getCurrentModuleDir(import.meta.url)
 
+function isSupportedCliPackage(name: string): name is SupportedCliPackage {
+  return (supportedCliPackages as readonly string[]).includes(name)
+}
+
 const findVersionRecursively = (currentDir: string, depth: number): string => {
   if (depth <= 0) {
     return '0.0.0'
@@ -25,7 +29,7 @@ const findVersionRecursively = (currentDir: string, depth: number): string => {
     const content = readFileSync(pkgPath, 'utf-8')
     const pkg = JSON.parse(content) as PackageInfo
 
-    return supportedCliPackages.includes(pkg.name as SupportedCliPackage)
+    return isSupportedCliPackage(pkg.name)
       ? pkg.version
       : findVersionRecursively(dirname(currentDir), depth - 1)
   } catch (_error) {

--- a/tools/pelela-cli/test/index.test.ts
+++ b/tools/pelela-cli/test/index.test.ts
@@ -41,5 +41,6 @@ describe('CLI structure', () => {
     ])
 
     expect(result.stdout).toMatch(/\d+\.\d+\.\d+/)
+    expect(result.stderr).toBe('')
   })
 })

--- a/tools/pelela-cli/test/index.test.ts
+++ b/tools/pelela-cli/test/index.test.ts
@@ -1,7 +1,8 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
 
-// Note: Testing the CLI entry point is challenging because it calls main() immediately
-// and has side effects. We test the individual components that make up the CLI.
+const execFileAsync = promisify(execFile)
 
 describe('CLI structure', () => {
   it('exports expected modules from commands', async () => {
@@ -27,5 +28,18 @@ describe('CLI structure', () => {
 
     expect(chalk.default).toBeDefined()
     expect(Command).toBeDefined()
+  })
+
+  it('runs the standalone CLI entrypoint in ESM mode and prints the version', async () => {
+    const result = await execFileAsync('pnpm', [
+      '-C',
+      'tools/pelela-cli',
+      'exec',
+      'tsx',
+      'src/index.ts',
+      '--version',
+    ])
+
+    expect(result.stdout).toMatch(/\d+\.\d+\.\d+/)
   })
 })

--- a/tools/pelela-cli/test/utils/templates.test.ts
+++ b/tools/pelela-cli/test/utils/templates.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initializeI18n } from '../../src/utils/i18n'
 import {
+  BASE_TEMPLATE_FOR_CLI,
   computeTemplatePath,
   copyTemplate,
   getTemplatePath,
@@ -40,15 +41,15 @@ describe('templates', () => {
       // simulate the file path ending in 'utils'
       const path = computeTemplatePath(join('/', 'mock', 'src', 'utils'))
       expect(path).toContain('templates')
-      expect(path).toContain('base-template-for-cli')
-      expect(path).toBe(join('/', 'mock', 'templates', 'base-template-for-cli'))
+      expect(path).toContain(BASE_TEMPLATE_FOR_CLI)
+      expect(path).toBe(join('/', 'mock', 'templates', BASE_TEMPLATE_FOR_CLI))
     })
 
     it('computes path for prod environment (dist)', () => {
       // simulate the bundled path 'dist'
       const path = computeTemplatePath(join('/', 'mock', 'dist'))
-      expect(path).toContain('base-template-for-cli')
-      expect(path).toBe(join('/', 'mock', 'dist', 'base-template-for-cli'))
+      expect(path).toContain(BASE_TEMPLATE_FOR_CLI)
+      expect(path).toBe(join('/', 'mock', 'dist', BASE_TEMPLATE_FOR_CLI))
     })
   })
 
@@ -105,7 +106,7 @@ describe('templates', () => {
       const path = getTemplatePath()
 
       expect(path).toContain('templates')
-      expect(path).toContain('base-template-for-cli')
+      expect(path).toContain(BASE_TEMPLATE_FOR_CLI)
     })
   })
 

--- a/tools/pelela-cli/test/utils/version.test.ts
+++ b/tools/pelela-cli/test/utils/version.test.ts
@@ -237,7 +237,7 @@ describe('getCliVersion', () => {
     readSpy.mockRestore()
   })
 
-  it('stops at the first recognized package (like vite-plugin-pelelajs)', async () => {
+  it('stops at the first supported package when it finds pelelajs', async () => {
     const fs = await import('node:fs')
     const { getCliVersion } = await import('../../src/utils/version')
 
@@ -247,7 +247,39 @@ describe('getCliVersion', () => {
       // First call: unrecognized package, should continue
       if (calls === 1) return JSON.stringify({ name: 'my-app', version: '1.0.0' })
       // Second call: recognized package, should stop
-      return JSON.stringify({ name: 'vite-plugin-pelelajs', version: '0.5.12' })
+      return JSON.stringify({ name: 'pelelajs', version: '0.5.12' })
+    })
+
+    const version = getCliVersion()
+    expect(version).toBe('0.5.12')
+    expect(calls).toBe(2)
+    readSpy.mockRestore()
+  })
+
+  it('keeps supporting the standalone CLI package as a fallback source', async () => {
+    const fs = await import('node:fs')
+    const { getCliVersion } = await import('../../src/utils/version')
+
+    const readSpy = vi
+      .spyOn(fs, 'readFileSync')
+      .mockImplementation(() => JSON.stringify({ name: '@pelelajs/cli', version: '0.5.12' }))
+
+    const version = getCliVersion()
+    expect(version).toBe('0.5.12')
+    readSpy.mockRestore()
+  })
+
+  it('ignores vite-plugin-pelelajs as a CLI version source', async () => {
+    const fs = await import('node:fs')
+    const { getCliVersion } = await import('../../src/utils/version')
+
+    let calls = 0
+    const readSpy = vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      calls++
+      if (calls === 1) {
+        return JSON.stringify({ name: 'vite-plugin-pelelajs', version: '9.9.9' })
+      }
+      return JSON.stringify({ name: 'pelelajs', version: '0.5.12' })
     })
 
     const version = getCliVersion()


### PR DESCRIPTION
## Qué cambia

- reutiliza la versión mínima de Node desde una única fuente de verdad
- extrae `base-template-for-cli` a una constante reutilizable
- alinea el update check del CLI con `pelelajs`
- deja de considerar `vite-plugin-pelelajs` como fuente válida para la versión del CLI
- corrige la resolución de paths para que el CLI standalone funcione en modo ESM
- agrega un smoke test del entrypoint standalone para `--version`

## Motivación

Esto cierra los follow-ups que habían quedado alrededor del release/npm y además cubre con un test el bug real que encontramos en el CLI standalone.

Fixes #95