### PR TITLE
Chore/97 translate vscode test descriptions

### DIFF
--- a/tools/pelela-vscode/test/parsers/definitionFinder.test.ts
+++ b/tools/pelela-vscode/test/parsers/definitionFinder.test.ts
@@ -63,7 +63,7 @@ export class UserViewModel {
   })
 
   describe('findClassDefinition', () => {
-    it('debería encontrar la definición de una clase exportada', () => {
+    it('should find the definition of an exported class', () => {
       const location = findClassDefinition(testVMPath, 'UserViewModel')
 
       assert.ok(location instanceof vscode.Location)
@@ -71,73 +71,73 @@ export class UserViewModel {
       assert.strictEqual(location?.range.start.line, 1)
     })
 
-    it('debería retornar null para una clase inexistente', () => {
+    it('should return null for a non-existent class', () => {
       const location = findClassDefinition(testVMPath, 'NonExistent')
       assert.strictEqual(location, null)
     })
   })
 
   describe('findPropertyDefinition', () => {
-    it('debería encontrar la definición de una propiedad pública', () => {
+    it('should find the definition of a public property', () => {
       const location = findPropertyDefinition(testVMPath, 'username')
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería encontrar la definición de una propiedad privada', () => {
+    it('should find the definition of a private property', () => {
       const location = findPropertyDefinition(testVMPath, 'password')
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería encontrar la definición de un getter', () => {
+    it('should find the definition of a getter', () => {
       const location = findPropertyDefinition(testVMPath, 'displayName')
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería retornar null para una propiedad inexistente', () => {
+    it('should return null for a non-existent property', () => {
       const location = findPropertyDefinition(testVMPath, 'nonExistent')
       assert.strictEqual(location, null)
     })
 
-    it('debería escapar caracteres especiales y retornar null de forma segura', () => {
+    it('should escape special characters and safely return null', () => {
       const location = findPropertyDefinition(testVMPath, 'test.*prop')
       assert.strictEqual(location, null)
     })
   })
 
   describe('findNestedPropertyDefinition', () => {
-    it('debería encontrar una propiedad anidada de primer nivel', () => {
+    it('should find a first-level nested property', () => {
       const location = findNestedPropertyDefinition(testVMPath, ['profile', 'bio'])
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería encontrar una propiedad profundamente anidada', () => {
+    it('should find a deeply nested property', () => {
       const location = findNestedPropertyDefinition(testVMPath, ['profile', 'settings', 'theme'])
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería retornar la definición simple si el path tiene un solo elemento', () => {
+    it('should return the simple definition if path has a single element', () => {
       const location = findNestedPropertyDefinition(testVMPath, ['username'])
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería retornar null para un path inexistente', () => {
+    it('should return null for a non-existent path', () => {
       const location = findNestedPropertyDefinition(testVMPath, ['profile', 'nonExistent'])
       assert.strictEqual(location, null)
     })
 
-    it('debería encontrar propiedades con caracteres especiales en rutas anidadas', () => {
+    it('should find properties with special characters in nested paths', () => {
       // Test the escaped rootPropertyName ($store) and targetProperty ($state) functionality
       const location = findNestedPropertyDefinition(testVMPath, ['$store', '$state'])
 
@@ -149,22 +149,22 @@ export class UserViewModel {
       assert.strictEqual(quotedLocation?.uri.fsPath, testVMPath)
     })
 
-    it('debería retornar null y evitar saltos inválidos si el inicio del objeto está corrupto', () => {
-      // testea el "return -1" cuando un '{' desasociado se encuentra luego de la propiedad
+    it('should return null and avoid invalid jumps if the object start is corrupted', () => {
+      // tests the "return -1" path when a stray '{' is found after the property
       const location = findNestedPropertyDefinition(testVMPath, ['brokenObject', 'prop'])
       assert.strictEqual(location, null)
     })
   })
 
   describe('findMethodDefinition', () => {
-    it('debería encontrar la definición de un método', () => {
+    it('should find the definition of a method', () => {
       const location = findMethodDefinition(testVMPath, 'handleLogin')
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('debería retornar null para un método inexistente', () => {
+    it('should return null for a non-existent method', () => {
       const location = findMethodDefinition(testVMPath, 'nonExistentMethod')
       assert.strictEqual(location, null)
     })

--- a/tools/pelela-vscode/test/parsers/definitionFinder.test.ts
+++ b/tools/pelela-vscode/test/parsers/definitionFinder.test.ts
@@ -125,7 +125,7 @@ export class UserViewModel {
       assert.strictEqual(location?.uri.fsPath, testVMPath)
     })
 
-    it('should return the simple definition if path has a single element', () => {
+    it('should return the simple definition if the path has a single element', () => {
       const location = findNestedPropertyDefinition(testVMPath, ['username'])
 
       assert.ok(location instanceof vscode.Location)

--- a/tools/pelela-vscode/test/parsers/documentParser.test.ts
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.ts
@@ -70,7 +70,7 @@ describe('documentParser', () => {
       assert.strictEqual(result, false)
     })
 
-    it('should return false if not inside a tag', () => {
+    it('should return false for plain text', () => {
       const result = isStartingTag('texto normal')
       assert.strictEqual(result, false)
     })

--- a/tools/pelela-vscode/test/parsers/documentParser.test.ts
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.ts
@@ -11,95 +11,95 @@ import {
 
 describe('documentParser', () => {
   describe('getCurrentAttributeName', () => {
-    it('debería extraer el nombre del atributo antes del cursor en un atributo con comillas', () => {
+    it('should extract the attribute name before the cursor in a quoted attribute', () => {
       const result = getCurrentAttributeName('<div bind-value="test', 21)
       assert.strictEqual(result, 'bind-value')
     })
 
-    it('debería retornar null si no hay atributo antes del cursor', () => {
+    it('should return null if there is no attribute before the cursor', () => {
       const result = getCurrentAttributeName('<div ', 5)
       assert.strictEqual(result, null)
     })
 
-    it('debería extraer atributos con guiones', () => {
+    it('should extract attributes with hyphens', () => {
       const result = getCurrentAttributeName('<div bind-class="active', 23)
       assert.strictEqual(result, 'bind-class')
     })
 
-    it('debería manejar espacios alrededor del signo igual', () => {
+    it('should handle spaces around the equals sign', () => {
       const result = getCurrentAttributeName('<div click = "handler', 21)
       assert.strictEqual(result, 'click')
     })
   })
 
   describe('isInsideTag', () => {
-    it('debería retornar true si está dentro de un tag', () => {
+    it('should return true if inside a tag', () => {
       const result = isInsideTag('<div ')
       assert.strictEqual(result, true)
     })
 
-    it('debería retornar true si está dentro de un tag con atributos', () => {
+    it('should return true if inside a tag with attributes', () => {
       const result = isInsideTag('<div class="test" ')
       assert.strictEqual(result, true)
     })
 
-    it('debería retornar false si no está dentro de un tag', () => {
+    it('should return false if not inside a tag', () => {
       const result = isInsideTag('some text')
       assert.strictEqual(result, false)
     })
 
-    it('debería retornar false si el tag está cerrado', () => {
+    it('should return false if the tag is closed', () => {
       const result = isInsideTag('<div>some text')
       assert.strictEqual(result, false)
     })
   })
 
   describe('isStartingTag', () => {
-    it('debería retornar true al comenzar un tag', () => {
+    it('should return true when starting a tag', () => {
       const result = isStartingTag('<d')
       assert.strictEqual(result, true)
     })
 
-    it('debería retornar true con un tag completo sin cerrar', () => {
+    it('should return true with a complete unclosed tag', () => {
       const result = isStartingTag('<div')
       assert.strictEqual(result, true)
     })
 
-    it('debería retornar false si hay un espacio después del nombre del tag', () => {
+    it('should return false if there is a space after the tag name', () => {
       const result = isStartingTag('<div ')
       assert.strictEqual(result, false)
     })
 
-    it('debería retornar false si no está en un tag', () => {
+    it('should return false if not inside a tag', () => {
       const result = isStartingTag('texto normal')
       assert.strictEqual(result, false)
     })
   })
 
   describe('getAttributeValueMatch', () => {
-    it('debería extraer el valor del atributo antes del cursor', () => {
+    it('should extract the attribute value before the cursor', () => {
       const result = getAttributeValueMatch('bind-value="test.prop')
       assert.strictEqual(result, 'test.prop')
     })
 
-    it('debería retornar null si no hay valor de atributo', () => {
+    it('should return null if there is no attribute value', () => {
       const result = getAttributeValueMatch('<div bind-value')
       assert.strictEqual(result, null)
     })
 
-    it('debería manejar valores vacíos', () => {
+    it('should handle empty values', () => {
       const result = getAttributeValueMatch('bind-value="')
       assert.strictEqual(result, '')
     })
 
-    it('debería manejar espacios alrededor del signo igual', () => {
+    it('should handle spaces around the equals sign', () => {
       const result = getAttributeValueMatch('bind-value = "test')
       assert.strictEqual(result, 'test')
     })
   })
 
   describe('parseForEachExpression', () => {
-    it('debería parsear una expresión for-each válida', () => {
+    it('should parse a valid for-each expression', () => {
       const result = parseForEachExpression('for-each="item of items"')
       assert.deepStrictEqual(result, {
         itemName: 'item',
@@ -107,7 +107,7 @@ describe('documentParser', () => {
       })
     })
 
-    it('debería parsear con comillas simples', () => {
+    it('should parse with single quotes', () => {
       const result = parseForEachExpression("for-each='product of products'")
       assert.deepStrictEqual(result, {
         itemName: 'product',
@@ -115,12 +115,12 @@ describe('documentParser', () => {
       })
     })
 
-    it('debería retornar null si la expresión es inválida', () => {
+    it('should return null if the expression is invalid', () => {
       const result = parseForEachExpression('for-each="invalid"')
       assert.strictEqual(result, null)
     })
 
-    it('debería manejar espacios extra', () => {
+    it('should handle extra spaces', () => {
       const result = parseForEachExpression('for-each="item of items"')
       assert.deepStrictEqual(result, {
         itemName: 'item',
@@ -130,27 +130,27 @@ describe('documentParser', () => {
   })
 
   describe('parsePropertyPath', () => {
-    it('debería parsear un path simple con punto al final', () => {
+    it('should parse a simple path with a trailing dot', () => {
       const result = parsePropertyPath('user.')
       assert.deepStrictEqual(result, ['user'])
     })
 
-    it('debería parsear un path anidado', () => {
+    it('should parse a nested path', () => {
       const result = parsePropertyPath('user.address.')
       assert.deepStrictEqual(result, ['user', 'address'])
     })
 
-    it('debería parsear un path profundamente anidado', () => {
+    it('should parse a deeply nested path', () => {
       const result = parsePropertyPath('user.address.street.')
       assert.deepStrictEqual(result, ['user', 'address', 'street'])
     })
 
-    it('debería retornar null si no termina con punto', () => {
+    it('should return null if it does not end with a dot', () => {
       const result = parsePropertyPath('user')
       assert.strictEqual(result, null)
     })
 
-    it('debería retornar null para string vacío', () => {
+    it('should return null for an empty string', () => {
       const result = parsePropertyPath('')
       assert.strictEqual(result, null)
     })

--- a/tools/pelela-vscode/test/parsers/viewModelParser.test.ts
+++ b/tools/pelela-vscode/test/parsers/viewModelParser.test.ts
@@ -75,7 +75,7 @@ interface Item {
       assert.ok(!methods.includes('constructor'))
     })
 
-    it('should not include constructor in methods', () => {
+    it('should not include the constructor in methods', () => {
       const { methods } = extractViewModelMembers(testVMPath)
       assert.ok(!methods.includes('constructor'))
     })
@@ -101,7 +101,7 @@ interface Item {
       assert.ok(props.includes('number'))
     })
 
-    it('should return empty array for non-existent properties', () => {
+    it('should return an empty array for non-existent properties', () => {
       const props = extractNestedProperties(testVMPath, ['nonExistent'])
       assert.strictEqual(props.length, 0)
     })
@@ -125,7 +125,7 @@ interface Item {
       assert.ok(props.includes('completed'))
     })
 
-    it('should return empty array for non-existent interfaces', () => {
+    it('should return an empty array for non-existent interfaces', () => {
       const testVMContent = fs.readFileSync(testVMPath, 'utf-8')
       const props = extractInterfaceProperties(testVMContent, 'NonExistent')
 

--- a/tools/pelela-vscode/test/parsers/viewModelParser.test.ts
+++ b/tools/pelela-vscode/test/parsers/viewModelParser.test.ts
@@ -61,7 +61,7 @@ interface Item {
   })
 
   describe('extractViewModelMembers', () => {
-    it('debería extraer propiedades y métodos de una clase', () => {
+    it('should extract properties and methods from a class', () => {
       const { properties, methods } = extractViewModelMembers(testVMPath)
 
       assert.ok(properties.includes('name'))
@@ -75,38 +75,38 @@ interface Item {
       assert.ok(!methods.includes('constructor'))
     })
 
-    it('no debería incluir constructor en los métodos', () => {
+    it('should not include constructor in methods', () => {
       const { methods } = extractViewModelMembers(testVMPath)
       assert.ok(!methods.includes('constructor'))
     })
 
-    it('debería incluir getters como propiedades', () => {
+    it('should include getters as properties', () => {
       const { properties } = extractViewModelMembers(testVMPath)
       assert.ok(properties.includes('fullName'))
     })
   })
 
   describe('extractNestedProperties', () => {
-    it('debería extraer propiedades anidadas de un objeto literal', () => {
+    it('should extract nested properties from an object literal', () => {
       const props = extractNestedProperties(testVMPath, ['user'])
 
       assert.ok(props.includes('name'))
       assert.ok(props.includes('address'))
     })
 
-    it('debería extraer propiedades profundamente anidadas', () => {
+    it('should extract deeply nested properties', () => {
       const props = extractNestedProperties(testVMPath, ['user', 'address'])
 
       assert.ok(props.includes('street'))
       assert.ok(props.includes('number'))
     })
 
-    it('debería retornar array vacío para propiedades inexistentes', () => {
+    it('should return empty array for non-existent properties', () => {
       const props = extractNestedProperties(testVMPath, ['nonExistent'])
       assert.strictEqual(props.length, 0)
     })
 
-    it('debería extraer propiedades de una interfaz cuando la propiedad es un array', () => {
+    it('should extract properties from an interface when the property is an array', () => {
       const props = extractNestedProperties(testVMPath, ['items'])
 
       assert.ok(props.includes('id'))
@@ -116,7 +116,7 @@ interface Item {
   })
 
   describe('extractInterfaceProperties', () => {
-    it('debería extraer propiedades de una interfaz', () => {
+    it('should extract properties from an interface', () => {
       const testVMContent = fs.readFileSync(testVMPath, 'utf-8')
       const props = extractInterfaceProperties(testVMContent, 'Item')
 
@@ -125,7 +125,7 @@ interface Item {
       assert.ok(props.includes('completed'))
     })
 
-    it('debería retornar array vacío para interfaces inexistentes', () => {
+    it('should return empty array for non-existent interfaces', () => {
       const testVMContent = fs.readFileSync(testVMPath, 'utf-8')
       const props = extractInterfaceProperties(testVMContent, 'NonExistent')
 

--- a/tools/pelela-vscode/test/utils/fileUtils.test.ts
+++ b/tools/pelela-vscode/test/utils/fileUtils.test.ts
@@ -28,14 +28,14 @@ describe('fileUtils', () => {
   })
 
   describe('findViewModelFile', () => {
-    it('debería encontrar el archivo ViewModel correspondiente', () => {
+    it('should find the corresponding ViewModel file', () => {
       const mockUri = { fsPath: testPelelaPath } as vscode.Uri
       const result = findViewModelFile(mockUri)
 
       assert.strictEqual(result, testTsPath)
     })
 
-    it('debería retornar null si no existe el archivo ViewModel', () => {
+    it('should return null if the ViewModel file does not exist', () => {
       const nonExistentPath = path.join(testFilesDir, 'nonexistent.pelela')
       const mockUri = { fsPath: nonExistentPath } as vscode.Uri
       const result = findViewModelFile(mockUri)
@@ -45,7 +45,7 @@ describe('fileUtils', () => {
   })
 
   describe('readFileLines', () => {
-    it('debería leer un archivo y retornar un array de líneas', () => {
+    it('should read a file and return an array of lines', () => {
       const testContent = 'line1\nline2\nline3'
       const testFile = path.join(testFilesDir, 'readtest.txt')
       fs.writeFileSync(testFile, testContent)
@@ -61,7 +61,7 @@ describe('fileUtils', () => {
       fs.unlinkSync(testFile)
     })
 
-    it('debería manejar archivos vacíos', () => {
+    it('should handle empty files', () => {
       const testFile = path.join(testFilesDir, 'empty.txt')
       fs.writeFileSync(testFile, '')
 
@@ -76,7 +76,7 @@ describe('fileUtils', () => {
   })
 
   describe('readFileContent', () => {
-    it('debería leer el contenido completo de un archivo', () => {
+    it('should read the complete file content', () => {
       const testContent = 'Hello World\nSecond line'
       const testFile = path.join(testFilesDir, 'content.txt')
       fs.writeFileSync(testFile, testContent)
@@ -88,7 +88,7 @@ describe('fileUtils', () => {
       fs.unlinkSync(testFile)
     })
 
-    it('debería manejar archivos vacíos', () => {
+    it('should handle empty files', () => {
       const testFile = path.join(testFilesDir, 'empty2.txt')
       fs.writeFileSync(testFile, '')
 

--- a/tools/pelela-vscode/test/utils/htmlUtils.test.ts
+++ b/tools/pelela-vscode/test/utils/htmlUtils.test.ts
@@ -4,14 +4,14 @@ import { getHtmlAttributes, getHtmlElements, getPelelaAttributes } from '../../s
 
 describe('htmlUtils', () => {
   describe('getHtmlElements', () => {
-    it('debería retornar un array de elementos HTML', () => {
+    it('should return an array of HTML elements', () => {
       const elements = getHtmlElements()
 
       assert.ok(Array.isArray(elements))
       assert.ok(elements.length > 0)
     })
 
-    it('debería incluir elementos comunes', () => {
+    it('should include common elements', () => {
       const elements = getHtmlElements()
 
       assert.ok(elements.includes('div'))
@@ -21,7 +21,7 @@ describe('htmlUtils', () => {
       assert.ok(elements.includes('section'))
     })
 
-    it('no debería incluir elementos duplicados', () => {
+    it('should not include duplicate elements', () => {
       const elements = getHtmlElements()
       const uniqueElements = [...new Set(elements)]
 
@@ -30,14 +30,14 @@ describe('htmlUtils', () => {
   })
 
   describe('getHtmlAttributes', () => {
-    it('debería retornar un array de atributos HTML', () => {
+    it('should return an array of HTML attributes', () => {
       const attributes = getHtmlAttributes()
 
       assert.ok(Array.isArray(attributes))
       assert.ok(attributes.length > 0)
     })
 
-    it('debería incluir atributos comunes', () => {
+    it('should include common attributes', () => {
       const attributes = getHtmlAttributes()
 
       assert.ok(attributes.includes('id'))
@@ -47,7 +47,7 @@ describe('htmlUtils', () => {
       assert.ok(attributes.includes('href'))
     })
 
-    it('debería incluir atributos con guiones', () => {
+    it('should include attributes with hyphens', () => {
       const attributes = getHtmlAttributes()
 
       assert.ok(attributes.includes('data-'))
@@ -56,14 +56,14 @@ describe('htmlUtils', () => {
   })
 
   describe('getPelelaAttributes', () => {
-    it('debería retornar un array de atributos de Pelela', () => {
+    it('should return an array of Pelela attributes', () => {
       const attributes = getPelelaAttributes()
 
       assert.ok(Array.isArray(attributes))
       assert.ok(attributes.length > 0)
     })
 
-    it('debería incluir todos los atributos de Pelela', () => {
+    it('should include all Pelela attributes', () => {
       const attributes = getPelelaAttributes()
 
       assert.ok(attributes.includes('view-model'))
@@ -75,7 +75,7 @@ describe('htmlUtils', () => {
       assert.ok(attributes.includes('for-each'))
     })
 
-    it('debería retornar exactamente 8 atributos', () => {
+    it('should return exactly 8 attributes', () => {
       const attributes = getPelelaAttributes()
       assert.strictEqual(attributes.length, 8)
     })

--- a/tools/pelela-vscode/test/utils/parsingUtils.test.ts
+++ b/tools/pelela-vscode/test/utils/parsingUtils.test.ts
@@ -10,107 +10,107 @@ import {
 
 describe('parsingUtils', () => {
   describe('calculateBraceDepth', () => {
-    it('debería retornar 0 para una línea con llaves balanceadas', () => {
+    it('should return 0 for a line with balanced braces', () => {
       assert.strictEqual(calculateBraceDepth('{ }'), 0)
       assert.strictEqual(calculateBraceDepth('{{ }}'), 0)
     })
 
-    it('debería retornar un número positivo para llaves abiertas de más', () => {
+    it('should return a positive number for extra opening braces', () => {
       assert.strictEqual(calculateBraceDepth('{'), 1)
       assert.strictEqual(calculateBraceDepth('{{'), 2)
       assert.strictEqual(calculateBraceDepth('{{ }'), 1)
     })
 
-    it('debería retornar un número negativo para llaves cerradas de más', () => {
+    it('should return a negative number for extra closing braces', () => {
       assert.strictEqual(calculateBraceDepth('}'), -1)
       assert.strictEqual(calculateBraceDepth('}}'), -2)
       assert.strictEqual(calculateBraceDepth('{ }}'), -1)
     })
 
-    it('debería retornar 0 si no hay llaves', () => {
+    it('should return 0 if there are no braces', () => {
       assert.strictEqual(calculateBraceDepth('export class MyClass'), 0)
     })
   })
 
   describe('isInterfaceDeclaration', () => {
-    it('debería retornar true para declaraciones de interfaz válidas', () => {
+    it('should return true for valid interface declarations', () => {
       assert.ok(isInterfaceDeclaration('interface MyInterface'))
       assert.ok(isInterfaceDeclaration('export interface MyInterface'))
       assert.ok(isInterfaceDeclaration('  interface MyInterface'))
     })
 
-    it('debería retornar false para otras declaraciones', () => {
+    it('should return false for other declarations', () => {
       assert.strictEqual(isInterfaceDeclaration('class MyClass'), false)
       assert.strictEqual(isInterfaceDeclaration('const interfaceName = "..."'), false)
     })
   })
 
   describe('isClassDeclaration', () => {
-    it('debería retornar true para declaraciones de clase válidas', () => {
+    it('should return true for valid class declarations', () => {
       assert.ok(isClassDeclaration('class MyClass'))
       assert.ok(isClassDeclaration('export class MyClass'))
       assert.ok(isClassDeclaration('  class MyClass'))
     })
 
-    it('debería retornar false para otras declaraciones', () => {
+    it('should return false for other declarations', () => {
       assert.strictEqual(isClassDeclaration('interface MyInterface'), false)
       assert.strictEqual(isClassDeclaration('const className = "..."'), false)
     })
   })
 
   describe('isObjectLiteralStart', () => {
-    it('debería retornar true si contiene asignación o dos puntos y una llave de apertura', () => {
+    it('should return true if it contains an assignment or colon and an opening brace', () => {
       assert.ok(isObjectLiteralStart('prop = {'))
       assert.ok(isObjectLiteralStart('prop: {'))
       assert.ok(isObjectLiteralStart('  nested: {'))
     })
 
-    it('debería retornar false si no cumple las condiciones', () => {
+    it('should return false if the conditions are not met', () => {
       assert.strictEqual(isObjectLiteralStart('prop = 5'), false)
-      assert.strictEqual(isObjectLiteralStart('class MyClass {'), false) // No tiene : ni =
+      assert.strictEqual(isObjectLiteralStart('class MyClass {'), false) // Has neither : nor =
     })
   })
 
   describe('findMemberMatch', () => {
-    it('debería detectar propiedades simples', () => {
+    it('should detect simple properties', () => {
       const match = findMemberMatch('  public name: string')
       assert.ok(match)
       assert.strictEqual(match?.name, 'name')
       assert.strictEqual(match?.type, 'property')
     })
 
-    it('debería detectar propiedades privadas', () => {
+    it('should detect private properties', () => {
       const match = findMemberMatch('  private _id = 1')
       assert.ok(match)
       assert.strictEqual(match?.name, '_id')
       assert.strictEqual(match?.type, 'property')
     })
 
-    it('debería detectar getters como propiedades', () => {
+    it('should detect getters as properties', () => {
       const match = findMemberMatch('  get fullName() {')
       assert.ok(match)
       assert.strictEqual(match?.name, 'fullName')
       assert.strictEqual(match?.type, 'property')
     })
 
-    it('debería detectar métodos', () => {
+    it('should detect methods', () => {
       const match = findMemberMatch('  save(data: any) {')
       assert.ok(match)
       assert.strictEqual(match?.name, 'save')
       assert.strictEqual(match?.type, 'method')
     })
 
-    it('debería ignorar constructores', () => {
+    it('should ignore constructors', () => {
       const match = findMemberMatch('  constructor() {')
       assert.strictEqual(match, null)
     })
 
-    it('debería ignorar palabras clave como if', () => {
+    it('should ignore keywords like if', () => {
       const match = findMemberMatch('  if (condition) {')
       assert.strictEqual(match, null)
     })
 
-    it('debería retornar null para líneas que no son miembros', () => {
+    it('should return null for lines that are not members', () => {
       assert.strictEqual(findMemberMatch('import { something } from "somewhere"'), null)
       assert.strictEqual(findMemberMatch('  return this.name'), null)
     })


### PR DESCRIPTION
## Resumen

Traduce al inglés las 73 descripciones de `it(...)` en los tests del plugin de VSCode, alineando con la regla de `AGENTS.md` ("código y comentarios en inglés").

## Cambios

- 73 descripciones de `it(...)` traducidas en 6 archivos bajo `tools/pelela-vscode/test/`.
- 2 comentarios en castellano traducidos (`definitionFinder.test.ts:153`, `parsingUtils.test.ts:70`).
- Desambiguada una descripción duplicada en `documentParser.test.ts`.
- No se modificó lógica de tests, assertions ni `describe(...)`.

Closes #97