### PR TITLE
Fix(pelela-vscode): assert bind-content in "all Pelela attributes" test

### DIFF
--- a/tools/pelela-vscode/test/utils/htmlUtils.test.ts
+++ b/tools/pelela-vscode/test/utils/htmlUtils.test.ts
@@ -68,6 +68,7 @@ describe('htmlUtils', () => {
 
       assert.ok(attributes.includes('view-model'))
       assert.ok(attributes.includes('bind-value'))
+      assert.ok(attributes.includes('bind-content'))
       assert.ok(attributes.includes('if'))
       assert.ok(attributes.includes('bind-class'))
       assert.ok(attributes.includes('bind-style'))


### PR DESCRIPTION
Agrega la aserción faltante de `bind-content` en el test `debería incluir todos los atributos de Pelela`. Detectado por CodeRabbit en #100 y separado en este PR por estar fuera del scope de ese PR.

Cierra #101