### PR TITLE
Task for each index

### DIFF
--- a/examples/components/src/home.pelela
+++ b/examples/components/src/home.pelela
@@ -3,8 +3,8 @@
     <h2>Ejemplo de Componentización Bidireccional</h2>
     <div class="layout">
       <div class="list">
-        <div for-each="person of people">
-          <person-row prop-person="person" prop-selected-index="selectedIndex"></person-row>
+        <div for-each="person of people" index="index">
+          <person-row prop-person="person" prop-index="index" prop-selected-index="selectedIndex"></person-row>
         </div>
       </div>
       <div class="sidebar">

--- a/examples/components/src/person-row.ts
+++ b/examples/components/src/person-row.ts
@@ -1,12 +1,17 @@
 export class PersonRow {
   person: { id: number; name: string } | null = null
   selectedIndex = -1
+  index = -1
 
   get isSelected() {
     return this.person?.id === this.selectedIndex
   }
 
+  get evenRow() {
+    return (this.index + 1) % 2 === 0
+  }
+
   get personClasses() {
-    return { selected: this.isSelected }
+    return { selected: this.isSelected, even: this.evenRow }
   }
 }

--- a/examples/components/src/styles.css
+++ b/examples/components/src/styles.css
@@ -95,3 +95,7 @@ h2 {
   min-width: 40px;
   text-align: center;
 }
+
+.even {
+  background-color: rgb(249, 248, 232);
+}

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -828,6 +828,51 @@ describe('bindForEach', () => {
       expect(itemRef.current).toBe('original')
     })
 
+    it('should return correct property descriptors via proxy traps', () => {
+      const itemRef = { current: { nested: 'value' } }
+      const indexRef = { current: 0 }
+      const viewModel = { items: [], parentProp: 'parent-value' }
+      const extendedViewModel = createExtendedViewModel({
+        parentViewModel: viewModel,
+        itemName: 'item',
+        itemRef,
+        indexName: 'i',
+        indexRef,
+      })
+
+      // Test descriptor for indexName
+      const indexDesc = Object.getOwnPropertyDescriptor(extendedViewModel, 'i')
+      expect(indexDesc).toEqual({
+        configurable: true,
+        enumerable: true,
+        value: undefined,
+        writable: false,
+      })
+
+      // Test descriptor for itemName
+      const itemDesc = Object.getOwnPropertyDescriptor(extendedViewModel, 'item')
+      expect(itemDesc).toEqual({
+        configurable: true,
+        enumerable: true,
+        value: undefined,
+        writable: false,
+      })
+
+      // Test descriptor for nested property path on itemName
+      const nestedDesc = Object.getOwnPropertyDescriptor(extendedViewModel, 'item.nested')
+      expect(nestedDesc).toEqual({
+        configurable: true,
+        enumerable: true,
+        value: undefined,
+        writable: false,
+      })
+
+      // Test descriptor for parent property
+      const parentDesc = Object.getOwnPropertyDescriptor(extendedViewModel, 'parentProp')
+      expect(parentDesc).toBeDefined()
+      expect(parentDesc?.value).toBe('parent-value')
+    })
+
     it('should work without index attribute (backward compatible)', () => {
       container.innerHTML = `
         <div for-each="item of items">
@@ -877,6 +922,34 @@ describe('bindForEach', () => {
 
       expect(binding).not.toBeNull()
       expect(binding!.extraDependencies).not.toContain('i')
+    })
+
+    it('should ignore empty or whitespace-only index attribute', () => {
+      container.innerHTML = `
+        <div for-each="item of items" index="   ">
+          <span bind-content="item.name"></span>
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Alice' }] }
+      const binding = setupSingleForEachBinding(
+        container.querySelector('[for-each]') as HTMLElement,
+        viewModel,
+      )
+
+      expect(binding).not.toBeNull()
+      expect(binding!.indexName).toBeNull()
+    })
+
+    it('should throw InvalidBindingSyntaxError if index is not a valid JS identifier', () => {
+      container.innerHTML = `
+        <div for-each="item of items" index="foo-bar">
+          <span bind-content="item.name"></span>
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Alice' }] }
+      expect(() => {
+        setupSingleForEachBinding(container.querySelector('[for-each]') as HTMLElement, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
     })
   })
 })

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -129,14 +129,20 @@ describe('bindForEach', () => {
       }).toThrowError(/element has no parent node/)
     })
 
-    it('should set item value through proxy', () => {
+    it('should make the item variable read-only through proxy (no index)', () => {
       const itemRef = { current: 'initial' }
       const viewModel = { items: ['initial'] }
-      const extendedViewModel = createExtendedViewModel(viewModel, 'item', itemRef)
+      const extendedViewModel = createExtendedViewModel({
+        parentViewModel: viewModel,
+        itemName: 'item',
+        itemRef,
+        indexName: null,
+        indexRef: { current: 0 },
+      })
 
-      // Test proxy set handler for item (lines 47-49)
+      // item is read-only — assignment has no effect
       extendedViewModel.item = 'updated'
-      expect(itemRef.current).toBe('updated')
+      expect(itemRef.current).toBe('initial')
     })
 
     describe('isBindingAttribute', () => {
@@ -148,6 +154,7 @@ describe('bindForEach', () => {
         expect(isBindingAttribute('click')).toBe(true)
         expect(isBindingAttribute('if')).toBe(true)
         expect(isBindingAttribute('for-each')).toBe(true)
+        expect(isBindingAttribute('index')).toBe(true)
       })
 
       it('should reject standard HTML attributes with hyphens', () => {
@@ -192,7 +199,13 @@ describe('bindForEach', () => {
     it('should handle setting nested properties through proxy', () => {
       const itemRef = { current: { name: 'initial' } }
       const viewModel = { items: [{ name: 'initial' }] }
-      const extendedViewModel = createExtendedViewModel(viewModel, 'item', itemRef)
+      const extendedViewModel = createExtendedViewModel({
+        parentViewModel: viewModel,
+        itemName: 'item',
+        itemRef,
+        indexName: null,
+        indexRef: { current: 0 },
+      })
 
       // Test proxy set handler for nested property (line 51)
       extendedViewModel['item.name'] = 'updated'
@@ -219,7 +232,13 @@ describe('bindForEach', () => {
     it('should handle setting parent viewModel properties through proxy', () => {
       const itemRef = { current: 1 }
       const viewModel = { items: [1], parentProp: 'initial' }
-      const extendedViewModel = createExtendedViewModel(viewModel, 'item', itemRef)
+      const extendedViewModel = createExtendedViewModel({
+        parentViewModel: viewModel,
+        itemName: 'item',
+        itemRef,
+        indexName: null,
+        indexRef: { current: 0 },
+      })
 
       // Test proxy set handler for parent property (lines 52-53)
       extendedViewModel.parentProp = 'updated'
@@ -702,6 +721,162 @@ describe('bindForEach', () => {
 
       expect(spans[0].classList.contains('active')).toBe(false)
       expect(spans[1].classList.contains('active')).toBe(true)
+    })
+  })
+
+  describe('index attribute in for-each', () => {
+    it('should expose the index variable in the for-each scope', () => {
+      container.innerHTML = `
+        <ul>
+          <li for-each="item of items" index="i">
+            <span bind-content="item.name"></span>
+            <span bind-content="i"></span>
+          </li>
+        </ul>
+      `
+
+      const viewModel = {
+        items: [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Carol' }],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const listItems = container.querySelectorAll('li')
+      expect(listItems).toHaveLength(3)
+      expect(listItems[0].querySelectorAll('span')[1].innerHTML).toBe('0')
+      expect(listItems[1].querySelectorAll('span')[1].innerHTML).toBe('1')
+      expect(listItems[2].querySelectorAll('span')[1].innerHTML).toBe('2')
+    })
+
+    it('should update index values when the array grows', () => {
+      container.innerHTML = `
+        <ul>
+          <li for-each="item of items" index="i">
+            <span bind-content="i"></span>
+          </li>
+        </ul>
+      `
+
+      const viewModel = { items: [{ name: 'Alice' }] }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      expect(container.querySelector('li span')?.innerHTML).toBe('0')
+
+      viewModel.items.push({ name: 'Bob' })
+      renderForEachBindings(bindings, viewModel)
+
+      const spans = container.querySelectorAll('li span')
+      expect(spans[0].innerHTML).toBe('0')
+      expect(spans[1].innerHTML).toBe('1')
+    })
+
+    it('should keep index values consistent when the array shrinks', () => {
+      container.innerHTML = `
+        <ul>
+          <li for-each="item of items" index="i">
+            <span bind-content="i"></span>
+          </li>
+        </ul>
+      `
+
+      const viewModel = { items: [{ name: 'Alice' }, { name: 'Bob' }, { name: 'Carol' }] }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      viewModel.items.pop()
+      renderForEachBindings(bindings, viewModel)
+
+      const spans = container.querySelectorAll('li span')
+      expect(spans).toHaveLength(2)
+      expect(spans[0].innerHTML).toBe('0')
+      expect(spans[1].innerHTML).toBe('1')
+    })
+
+    it('should make the index variable read-only (assignment has no effect)', () => {
+      const itemRef = { current: 'item' }
+      const indexRef = { current: 0 }
+      const viewModel = { items: ['item'] }
+      const extendedViewModel = createExtendedViewModel({
+        parentViewModel: viewModel,
+        itemName: 'item',
+        itemRef,
+        indexName: 'i',
+        indexRef,
+      })
+
+      extendedViewModel.i = 99
+      expect(indexRef.current).toBe(0)
+    })
+
+    it('should make the item variable read-only (assignment has no effect)', () => {
+      const itemRef = { current: 'original' }
+      const indexRef = { current: 0 }
+      const viewModel = { items: ['original'] }
+      const extendedViewModel = createExtendedViewModel({
+        parentViewModel: viewModel,
+        itemName: 'item',
+        itemRef,
+        indexName: 'i',
+        indexRef,
+      })
+
+      extendedViewModel.item = 'mutated'
+      expect(itemRef.current).toBe('original')
+    })
+
+    it('should work without index attribute (backward compatible)', () => {
+      container.innerHTML = `
+        <div for-each="item of items">
+          <span bind-content="item.text"></span>
+        </div>
+      `
+
+      const viewModel = { items: [{ text: 'Hello' }, { text: 'World' }] }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const spans = container.querySelectorAll('span')
+      expect(spans[0].innerHTML).toBe('Hello')
+      expect(spans[1].innerHTML).toBe('World')
+    })
+
+    it('should remove the index attribute from rendered DOM elements', () => {
+      container.innerHTML = `
+        <ul>
+          <li for-each="item of items" index="i">
+            <span bind-content="item.name"></span>
+          </li>
+        </ul>
+      `
+
+      const viewModel = { items: [{ name: 'Alice' }] }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const renderedLi = container.querySelector('li')
+      expect(renderedLi?.hasAttribute('index')).toBe(false)
+    })
+
+    it('should not register index as an external dependency', () => {
+      container.innerHTML = `
+        <div for-each="item of items" index="i">
+          <span bind-content="item.name"></span>
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Alice' }] }
+      const binding = setupSingleForEachBinding(
+        container.querySelector('[for-each]') as HTMLElement,
+        viewModel,
+      )
+
+      expect(binding).not.toBeNull()
+      expect(binding!.extraDependencies).not.toContain('i')
     })
   })
 })

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -951,5 +951,29 @@ describe('bindForEach', () => {
         setupSingleForEachBinding(container.querySelector('[for-each]') as HTMLElement, viewModel)
       }).toThrow(InvalidBindingSyntaxError)
     })
+
+    it('should throw InvalidBindingSyntaxError if index starts with a number (0foo)', () => {
+      container.innerHTML = `
+        <div for-each="item of items" index="0foo">
+          <span bind-content="item.name"></span>
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Alice' }] }
+      expect(() => {
+        setupSingleForEachBinding(container.querySelector('[for-each]') as HTMLElement, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
+
+    it('should throw InvalidBindingSyntaxError if index is only numbers (123)', () => {
+      container.innerHTML = `
+        <div for-each="item of items" index="123">
+          <span bind-content="item.name"></span>
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Alice' }] }
+      expect(() => {
+        setupSingleForEachBinding(container.querySelector('[for-each]') as HTMLElement, viewModel)
+      }).toThrow(InvalidBindingSyntaxError)
+    })
   })
 })

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -111,7 +111,11 @@ export function setupSingleForEachBinding<T extends object>(
   const parsed = parseForEachExpression(expression)
   if (!parsed) throw new InvalidBindingSyntaxError('for-each', expression, 'item of collection')
   const { itemName, collectionName } = parsed
-  const indexName = element.getAttribute('index') || null
+  const rawIndexName = element.getAttribute('index')
+  const indexName = rawIndexName?.trim() ? rawIndexName.trim() : null
+  if (indexName && !/^\w+$/.test(indexName)) {
+    throw new InvalidBindingSyntaxError('index', rawIndexName ?? '', 'valid identifier')
+  }
   assertViewModelProperty(viewModel, collectionName, 'for-each', element)
   const collection = viewModel[collectionName]
   if (!Array.isArray(collection)) {

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -3,7 +3,9 @@ import {
   extractElementSnippet,
   filterOwnElements,
   findAllElements,
+  IDENTIFIER_PATTERN,
   isPropertyOrNestedPath,
+  isValidIdentifier,
 } from '../commons/helpers'
 import {
   InvalidBindingSyntaxError,
@@ -25,7 +27,8 @@ import type { ForEachBinding, ViewModel } from './types'
 function parseForEachExpression(
   expression: string,
 ): { itemName: string; collectionName: string } | null {
-  const match = expression.trim().match(/^(\w+)\s+of\s+(\w+)$/)
+  const identifier = IDENTIFIER_PATTERN.source.replace(/^\^|\$$/g, '')
+  const match = expression.trim().match(new RegExp(`^(${identifier})\\s+of\\s+(${identifier})$`))
   if (!match) return null
   return { itemName: match[1], collectionName: match[2] }
 }
@@ -113,7 +116,7 @@ export function setupSingleForEachBinding<T extends object>(
   const { itemName, collectionName } = parsed
   const rawIndexName = element.getAttribute('index')
   const indexName = rawIndexName?.trim() ? rawIndexName.trim() : null
-  if (indexName && !/^\w+$/.test(indexName)) {
+  if (indexName && !isValidIdentifier(indexName)) {
     throw new InvalidBindingSyntaxError('index', rawIndexName ?? '', 'valid identifier')
   }
   assertViewModelProperty(viewModel, collectionName, 'for-each', element)
@@ -131,7 +134,7 @@ export function setupSingleForEachBinding<T extends object>(
   // Remove framework-specific attributes from the template so they don't appear
   // as raw HTML attributes on every cloned element rendered in the DOM.
   template.removeAttribute('for-each')
-  if (indexName) template.removeAttribute('index')
+  if (rawIndexName !== null) template.removeAttribute('index')
   if (!element.parentNode)
     throw new InvalidDOMStructureError('for-each', 'element has no parent node')
   const placeholder = document.createComment(`for-each: ${itemName} of ${collectionName}`)

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -30,25 +30,37 @@ function parseForEachExpression(
   return { itemName: match[1], collectionName: match[2] }
 }
 
-export function createExtendedViewModel<T extends object>(
-  parentViewModel: ViewModel<T>,
-  itemName: string,
-  itemRef: { current: unknown },
-): ViewModel {
+type ExtendedViewModelOptions<T extends object> = {
+  parentViewModel: ViewModel<T>
+  itemName: string
+  itemRef: { current: unknown }
+  indexName: string | null
+  indexRef: { current: number }
+}
+
+export function createExtendedViewModel<T extends object>({
+  parentViewModel,
+  itemName,
+  itemRef,
+  indexName,
+  indexRef,
+}: ExtendedViewModelOptions<T>): ViewModel {
   return new Proxy(
     {},
     {
       has(_target, prop) {
+        if (prop === indexName) return true
         if (isPropertyOrNestedPath(prop, itemName)) return true
         return prop in parentViewModel
       },
       getOwnPropertyDescriptor(_target, prop) {
-        if (isPropertyOrNestedPath(prop, itemName)) {
+        if (prop === indexName || isPropertyOrNestedPath(prop, itemName)) {
           return { configurable: true, enumerable: true, value: undefined } // value isn't strictly needed for hasOwn, but we provide a valid descriptor
         }
         return Object.getOwnPropertyDescriptor(parentViewModel, prop)
       },
       get(_target, prop) {
+        if (prop === indexName) return indexRef.current
         if (prop === itemName) return itemRef.current
         if (isPropertyOrNestedPath(prop, itemName)) {
           const itemProp = (prop as string).substring(itemName.length + 1)
@@ -57,11 +69,8 @@ export function createExtendedViewModel<T extends object>(
         return parentViewModel[prop as string]
       },
       set(_target, prop, value) {
-        if (prop === itemName) {
-          itemRef.current = value
-          return true
-        }
-        if (isPropertyOrNestedPath(prop, itemName)) return true
+        // Both index and item variables are read-only within the for-each scope
+        if (prop === indexName || isPropertyOrNestedPath(prop, itemName)) return true
         ;(parentViewModel as Record<string, unknown>)[prop as string] = value
         return true
       },
@@ -102,6 +111,7 @@ export function setupSingleForEachBinding<T extends object>(
   const parsed = parseForEachExpression(expression)
   if (!parsed) throw new InvalidBindingSyntaxError('for-each', expression, 'item of collection')
   const { itemName, collectionName } = parsed
+  const indexName = element.getAttribute('index') || null
   assertViewModelProperty(viewModel, collectionName, 'for-each', element)
   const collection = viewModel[collectionName]
   if (!Array.isArray(collection)) {
@@ -114,16 +124,20 @@ export function setupSingleForEachBinding<T extends object>(
     })
   }
   const template = element.cloneNode(true) as HTMLElement
+  // Remove framework-specific attributes from the template so they don't appear
+  // as raw HTML attributes on every cloned element rendered in the DOM.
   template.removeAttribute('for-each')
+  if (indexName) template.removeAttribute('index')
   if (!element.parentNode)
     throw new InvalidDOMStructureError('for-each', 'element has no parent node')
   const placeholder = document.createComment(`for-each: ${itemName} of ${collectionName}`)
   element.parentNode.insertBefore(placeholder, element)
-  const extraDependencies = extractExtraDependencies(element, itemName, collectionName)
+  const extraDependencies = extractExtraDependencies(element, itemName, collectionName, indexName)
   element.remove()
   return {
     collectionName,
     itemName,
+    indexName,
     template,
     placeholder,
     renderedElements: [],
@@ -131,6 +145,9 @@ export function setupSingleForEachBinding<T extends object>(
     extraDependencies,
   }
 }
+
+const EXACT_BINDING_ATTRIBUTES = ['click', 'if', 'for-each', 'index'] as const
+type ExactBindingAttribute = (typeof EXACT_BINDING_ATTRIBUTES)[number]
 
 export function isBindingAttribute(attrName: string): boolean {
   // Exclude standard HTML attributes that contain hyphens
@@ -147,9 +164,7 @@ export function isBindingAttribute(attrName: string): boolean {
     attrName.startsWith('bind-') ||
     attrName.startsWith(LINK_PREFIX) ||
     attrName.startsWith(PROP_PREFIX) ||
-    attrName === 'click' ||
-    attrName === 'if' ||
-    attrName === 'for-each'
+    EXACT_BINDING_ATTRIBUTES.includes(attrName as ExactBindingAttribute)
   )
 }
 
@@ -158,14 +173,24 @@ export function isCustomComponent(element: HTMLElement): boolean {
   return getComponentByTag(tagName) !== undefined
 }
 
-function isExternalDependency(propPath: string, itemName: string, collectionName: string): boolean {
-  return !isPropertyOrNestedPath(propPath, itemName) && propPath !== collectionName
+function isExternalDependency(
+  propPath: string,
+  itemName: string,
+  collectionName: string,
+  indexName: string | null,
+): boolean {
+  return (
+    !isPropertyOrNestedPath(propPath, itemName) &&
+    (indexName === null || !isPropertyOrNestedPath(propPath, indexName)) &&
+    propPath !== collectionName
+  )
 }
 
 function extractExtraDependencies(
   parentElement: HTMLElement,
   itemName: string,
   collectionName: string,
+  indexName: string | null,
 ): string[] {
   const allElements = [
     parentElement,
@@ -175,13 +200,20 @@ function extractExtraDependencies(
 
   return allAttributes
     .filter((attr) => {
+      // Exclude loop definition attributes on the parent element itself
+      const isParentLoopDefinition =
+        attr.ownerElement === parentElement && (attr.name === 'for-each' || attr.name === 'index')
+      if (isParentLoopDefinition) return false
+
       const isFrameworkBinding = isBindingAttribute(attr.name)
       const isKebabCaseProp = attr.name.includes('-') && !isFrameworkBinding
       const element = attr.ownerElement as HTMLElement
       return isFrameworkBinding || (isKebabCaseProp && isCustomComponent(element))
     })
     .map((attr) => attr.value)
-    .filter((propPath) => propPath && isExternalDependency(propPath, itemName, collectionName))
+    .filter(
+      (propPath) => propPath && isExternalDependency(propPath, itemName, collectionName, indexName),
+    )
     .map((propPath) => propPath.split('.')[0])
 }
 
@@ -200,14 +232,28 @@ function createNewElement<T extends object>(
   binding: ForEachBinding,
   viewModel: ViewModel<T>,
   item: unknown,
+  index: number,
 ): void {
   const element = binding.template.cloneNode(true) as HTMLElement
   const itemRef = { current: item }
-  const extendedViewModel = createExtendedViewModel(viewModel, binding.itemName, itemRef)
+  const indexRef = { current: index }
+  const extendedViewModel = createExtendedViewModel({
+    parentViewModel: viewModel,
+    itemName: binding.itemName,
+    itemRef,
+    indexName: binding.indexName,
+    indexRef,
+  })
   const render = setupBindingsForElement(element, extendedViewModel)
   const lastElement =
     binding.renderedElements[binding.renderedElements.length - 1]?.element || binding.placeholder
-  binding.renderedElements.push({ element, viewModel: extendedViewModel, itemRef, render })
+  binding.renderedElements.push({
+    element,
+    viewModel: extendedViewModel,
+    itemRef,
+    indexRef,
+    render,
+  })
   if (lastElement.parentNode) {
     lastElement.parentNode.insertBefore(element, lastElement.nextSibling)
     render()
@@ -220,8 +266,8 @@ function addNewElements<T extends object>(
   collection: unknown[],
   previousLength: number,
 ): void {
-  collection.slice(previousLength).forEach((item) => {
-    createNewElement(binding, viewModel, item)
+  collection.slice(previousLength).forEach((item, sliceIndex) => {
+    createNewElement(binding, viewModel, item, previousLength + sliceIndex)
   })
 }
 
@@ -234,6 +280,7 @@ function removeExtraElements(binding: ForEachBinding, currentLength: number): vo
 function updateExistingElements(binding: ForEachBinding, collection: unknown[]): void {
   binding.renderedElements.forEach((rendered, index) => {
     rendered.itemRef.current = collection[index]
+    rendered.indexRef.current = index
     rendered.render()
   })
 }

--- a/packages/core/src/bindings/dependencyTracker.test.ts
+++ b/packages/core/src/bindings/dependencyTracker.test.ts
@@ -211,6 +211,7 @@ describe('DependencyTracker', () => {
       const forEachBinding = {
         collectionName: 'users',
         itemName: 'user',
+        indexName: null,
         template: document.createElement('div'),
         placeholder: document.createComment(''),
         renderedElements: [],
@@ -350,6 +351,7 @@ describe('DependencyTracker', () => {
       const forEachBinding = {
         collectionName: 'people',
         itemName: 'person',
+        indexName: null,
         template: document.createElement('div'),
         placeholder: document.createComment(''),
         renderedElements: [],
@@ -453,6 +455,7 @@ describe('DependencyTracker', () => {
       const forEachBinding = {
         collectionName: 'items',
         itemName: 'item',
+        indexName: null,
         template: document.createElement('div'),
         placeholder: document.createComment(''),
         renderedElements: [],

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -36,12 +36,14 @@ export type StyleBinding = {
 export type ForEachBinding = {
   collectionName: string
   itemName: string
+  indexName: string | null
   template: HTMLElement
   placeholder: Comment
   renderedElements: {
     element: HTMLElement
     viewModel: ViewModel
     itemRef: { current: unknown }
+    indexRef: { current: number }
     render: () => void
   }[]
   previousLength: number

--- a/packages/core/src/commons/helpers.test.ts
+++ b/packages/core/src/commons/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   findAllElements,
   isObject,
   isPropertyOrNestedPath,
+  isValidIdentifier,
   toCamelCase,
   toKebabCase,
   unwrapTemplate,
@@ -255,6 +256,52 @@ describe('helpers', () => {
 
       const result = findAllElements(root, '[bind-class]')
       expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('isValidIdentifier', () => {
+    it('should return true for valid identifiers starting with letters', () => {
+      expect(isValidIdentifier('item')).toBe(true)
+      expect(isValidIdentifier('myVar')).toBe(true)
+    })
+
+    it('should return true for valid identifiers starting with underscore', () => {
+      expect(isValidIdentifier('_private')).toBe(true)
+    })
+
+    it('should return true for valid identifiers starting with dollar sign', () => {
+      expect(isValidIdentifier('$jquery')).toBe(true)
+    })
+
+    it('should return true for valid identifiers with numbers after first character', () => {
+      expect(isValidIdentifier('item1')).toBe(true)
+    })
+
+    it('should return false for identifiers starting with numbers', () => {
+      expect(isValidIdentifier('0foo')).toBe(false)
+      expect(isValidIdentifier('123')).toBe(false)
+    })
+
+    it('should return false for empty string', () => {
+      expect(isValidIdentifier('')).toBe(false)
+    })
+
+    it('should return false for identifiers with hyphens', () => {
+      expect(isValidIdentifier('my-var')).toBe(false)
+    })
+
+    it('should return false for identifiers with spaces', () => {
+      expect(isValidIdentifier('my var')).toBe(false)
+    })
+
+    it('should return false for identifiers with special characters', () => {
+      expect(isValidIdentifier('my@var')).toBe(false)
+    })
+
+    it('should return false for unsafe prototype pollution keys', () => {
+      expect(isValidIdentifier('__proto__')).toBe(false)
+      expect(isValidIdentifier('constructor')).toBe(false)
+      expect(isValidIdentifier('prototype')).toBe(false)
     })
   })
 })

--- a/packages/core/src/commons/helpers.ts
+++ b/packages/core/src/commons/helpers.ts
@@ -1,7 +1,10 @@
 import { getRegisteredTags } from '../registry/componentRegistry'
 import { t } from './i18n'
+import { isUnsafeKey } from './sanitization'
 
 export const ELEMENT_SNIPPET_MAX_LENGTH = 100
+
+export const IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/
 
 export function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object'
@@ -76,4 +79,8 @@ export function findAllElements(
     ...(includeRoot && root.matches(selector) ? [root] : []),
     ...Array.from(root.querySelectorAll<HTMLElement>(selector)),
   ]
+}
+
+export function isValidIdentifier(value: string): boolean {
+  return IDENTIFIER_PATTERN.test(value) && !isUnsafeKey(value)
 }

--- a/packages/core/src/errors/PropertyValidationError.ts
+++ b/packages/core/src/errors/PropertyValidationError.ts
@@ -8,6 +8,7 @@ export type BindingKind =
   | 'bind-style'
   | 'for-each'
   | 'if'
+  | 'index'
 
 interface PropertyValidationErrorParams {
   propertyName: string

--- a/tools/pelela-vscode/html-custom-data.json
+++ b/tools/pelela-vscode/html-custom-data.json
@@ -62,6 +62,11 @@
       "name": "for-each",
       "description": "Pelela: Iterates over a collection from the ViewModel (syntax: item of collection)",
       "valueSet": "v"
+    },
+    {
+      "name": "index",
+      "description": "Pelela: Specifies the index variable name for for-each loops",
+      "valueSet": "v"
     }
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,9 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "baseUrl": ".",
     "paths": {
-      "pelelajs": ["packages/core/src/index.ts"]
+      "pelelajs": ["./packages/core/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
En este PR metí el agregado de un "index", como lo muestra el ejemplo de los componentes:

```html
        <div for-each="person of people" index="index">
          <person-row prop-person="person" prop-index="index" prop-selected-index="selectedIndex"></person-row>
```

Como hoy prohibimos el uso de expresiones dentro de los mecanismos de binding, lo más simple para poder usarlo es pasarlo como prop a un componente hijo:

```ts
export class PersonRow {
  person: { id: number; name: string } | null = null
  selectedIndex = -1
  index = -1

  get isSelected() {
    return this.person?.id === this.selectedIndex
  }

  get evenRow() {
    return (this.index + 1) % 2 === 0
  }

  get personClasses() {
    return { selected: this.isSelected, even: this.evenRow }
  }
}
```

Eso hace que puedas diferenciar filas pares de impares (aunque tanto no se nota cuando encima marcás el seleccionado):

<img width="799" height="249" alt="Screenshot 2026-05-19 at 8 45 10 PM" src="https://github.com/user-attachments/assets/88eb1403-bce5-4bfa-b126-37e8d0f9bce2" />

Dentro del contexto del foreach original no le veo mucho sentido, pero no quería cerrar el ticket ahora que lo tengo implementado por dos razones:

1. quizás el día de mañana sí agregamos expresiones de TS dentro de Pelela y ahí ya cambia la cosa
2. tener el index dispara otras cosas que hoy no se me ocurren

También arreglé un warning de tsconfig, ahora que volví a VSCode porque Antigravity dejó de existir como IDE.  

