### PR TITLE
Fix ejemplo Ruleta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
     - **Comentarios:** Explicar el "porqué", no el "qué". No agregar comentarios inline en internas. Evitar comentarios inútiles. Prohibido usar comentarios inline en el medio de un método. Se permiten y deben preservarse los comentarios que describan el propósito o comportamiento de un método o test.
     - **Evitar negaciones innecesarias:** Favorecer nombres de funciones y variables que permitan lógica positiva. Evitar la doble negación (ej: facilitar `isValid` o `isUnsafe` para evitar `!isInvalid` o `!isSafe`).
     - **Consistencia:** Mantener estilo uniforme en todo el proyecto.
-    - **Markdown Formatting:** Siempre incluir una línea en blanco antes de cada encabezado (headings) y antes de los bloques de código dentro de listas (bullets/numbered lists).
+    - **Markdown Formatting:** Siempre incluir una línea en blanco antes de cada encabezado (headings) y antes de los bloques de código dentro de listas (bullets/numbered lists). Asegurar que todos los bloques de código declaren un lenguaje (ej. ```typescript o ```json) en lugar de dejarlos sin tipo. **SE RESPETA markdownlint** cuando se trabaja con archivos markdown **salvo para los planes de AI**.
     - **Linting CSS:** Seguir estándares de Stylelint: preferir strings en `@import` (sin `url()`) y evitar comillas en nombres de fuentes de una sola palabra (ej: usar `Inter` en lugar de `'Inter'`).
   </style_and_clean_code>
 

--- a/examples/for-each/src/app.pelela
+++ b/examples/for-each/src/app.pelela
@@ -97,5 +97,28 @@
     <button click="searchUser">Buscar</button>
   </div>
   <p bind-content="userSearched" class="result-text"></p>
-  
+
+  <hr/>
+
+  <h2>8) Paths anidados en for-each</h2>
+
+  <p>Iterar sobre una propiedad anidada del ViewModel (filtrando pares con un getter)</p>
+
+  <div for-each="value of evenValues" class="card">
+    <span bind-content="value" class="result-text"></span>
+  </div>
+
+  <hr/>
+
+  <h2>9) Select con objetos (valor automático de option)</h2>
+
+  <p>El valor del option es el objeto completo, no solo el texto</p>
+
+  <select bind-value="selectedType">
+    <option for-each="type of types" bind-content="type.description"></option>
+  </select>
+
+  <p>Objeto seleccionado: <span bind-content="selectedType.description"></span></p>
+  <p>Valor numérico: <span bind-content="selectedType.value"></span></p>
+
 </pelela>

--- a/examples/for-each/src/app.ts
+++ b/examples/for-each/src/app.ts
@@ -14,7 +14,7 @@ interface BetType {
   active?: boolean
 }
 
-interface Type {
+interface SelectableType {
   description: string
   value: number
 }
@@ -72,13 +72,13 @@ export class App {
   }
 
   // 9) Ejemplo Select con objetos
-  types: Type[] = [
+  types: SelectableType[] = [
     { description: 'Type A', value: 1 },
     { description: 'Type B', value: 2 },
     { description: 'Type C', value: 3 },
   ]
 
-  selectedType: Type = this.types[0]
+  selectedType: SelectableType = this.types[0]
 
   addUser() {
     if (!this.newUserName || !this.newUserEmail) return

--- a/examples/for-each/src/app.ts
+++ b/examples/for-each/src/app.ts
@@ -14,6 +14,11 @@ interface BetType {
   active?: boolean
 }
 
+interface Type {
+  description: string
+  value: number
+}
+
 export class App {
   // 1) Ejemplo Select
   // 3) Ejemplo de filtros dinámicos (if + for-each)
@@ -56,6 +61,24 @@ export class App {
   newUserEmail: string = ''
   userSearch: string = ''
   userSearched: string = ''
+
+  // 8) Ejemplo Paths anidados en for-each
+  nested: { values: number[] } = {
+    values: [1, 2, 3, 4],
+  }
+
+  get evenValues(): number[] {
+    return this.nested.values.filter((value) => value % 2 === 0)
+  }
+
+  // 9) Ejemplo Select con objetos
+  types: Type[] = [
+    { description: 'Type A', value: 1 },
+    { description: 'Type B', value: 2 },
+    { description: 'Type C', value: 3 },
+  ]
+
+  selectedType: Type = this.types[0]
 
   addUser() {
     if (!this.newUserName || !this.newUserEmail) return

--- a/examples/hello-world/src/app.pelela
+++ b/examples/hello-world/src/app.pelela
@@ -7,5 +7,6 @@
     <button click="decrement">-</button>
     <p bind-content="counter"></p>
     <button click="increment">+</button>
+    <row const-dato="eso"></row>
   </div>
 </pelela>

--- a/examples/hello-world/src/app.pelela
+++ b/examples/hello-world/src/app.pelela
@@ -7,6 +7,5 @@
     <button click="decrement">-</button>
     <p bind-content="counter"></p>
     <button click="increment">+</button>
-    <row const-dato="eso"></row>
   </div>
 </pelela>

--- a/examples/hello-world/src/row.css
+++ b/examples/hello-world/src/row.css
@@ -1,0 +1,1 @@
+/* Styles for Row component */

--- a/examples/hello-world/src/row.css
+++ b/examples/hello-world/src/row.css
@@ -1,1 +1,0 @@
-/* Styles for Row component */

--- a/examples/hello-world/src/row.pelela
+++ b/examples/hello-world/src/row.pelela
@@ -1,3 +1,0 @@
-<component view-model="Row">
-  <span bind-content="dato"/>
-</component>

--- a/examples/hello-world/src/row.pelela
+++ b/examples/hello-world/src/row.pelela
@@ -1,0 +1,3 @@
+<component view-model="Row">
+  <span bind-content="dato"/>
+</component>

--- a/examples/hello-world/src/row.ts
+++ b/examples/hello-world/src/row.ts
@@ -1,3 +1,0 @@
-export class Row {
-  dato: string = ''
-}

--- a/examples/hello-world/src/row.ts
+++ b/examples/hello-world/src/row.ts
@@ -1,0 +1,3 @@
+export class Row {
+  dato: string = ''
+}

--- a/examples/nested-prop-component/.npmrc
+++ b/examples/nested-prop-component/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/examples/nested-prop-component/index.html
+++ b/examples/nested-prop-component/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nested prop-* Reactivity Bug</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/main.ts"></script>
+</body>
+</html>

--- a/examples/nested-prop-component/index.html
+++ b/examples/nested-prop-component/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nested prop-* Reactivity Bug</title>
+  <title>Nested prop Reactivity Example</title>
 </head>
 <body>
   <div id="app"></div>

--- a/examples/nested-prop-component/main.ts
+++ b/examples/nested-prop-component/main.ts
@@ -1,0 +1,7 @@
+import './src/styles.css'
+import { router } from 'pelelajs'
+import { routes } from './routes'
+import 'virtual:pelela-auto-register'
+
+const root = document.getElementById('app') ?? document.body
+router.start(root, routes)

--- a/examples/nested-prop-component/package.json
+++ b/examples/nested-prop-component/package.json
@@ -1,8 +1,7 @@
 {
   "name": "pelelajs-example-nested-prop-component",
   "version": "1.0.0",
-  "description": "Ejemplo mínimo reproduciendo bug de reactividad en prop- anidadas",
-  "main": "index.js",
+  "description": "Nested property example for components",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/examples/nested-prop-component/package.json
+++ b/examples/nested-prop-component/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "pelelajs-example-nested-prop-component",
+  "version": "1.0.0",
+  "description": "Ejemplo mínimo reproduciendo bug de reactividad en prop- anidadas",
+  "main": "index.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "pelelajs": "workspace:*",
+    "vite-plugin-pelelajs": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "7.2.4",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/nested-prop-component/routes.ts
+++ b/examples/nested-prop-component/routes.ts
@@ -1,0 +1,4 @@
+import type { RouteDefinition } from 'pelelajs'
+import { Bet } from './src/bet'
+
+export const routes: RouteDefinition[] = [{ path: '/', component: Bet }]

--- a/examples/nested-prop-component/src/bet.pelela
+++ b/examples/nested-prop-component/src/bet.pelela
@@ -2,11 +2,15 @@
   <div class="container">
     <h1>Place Bet</h1>
     <div class="form-group">
+      <label for="date">Date:</label>
+      <input id="date" type="date" bind-value="bet.date" />
+      <validator const-field-name="date" prop-errors="bet.errors"></validator>
+    </div>
+    <div class="form-group">
       <label for="amount">Amount:</label>
       <input id="amount" type="number" bind-value="bet.amount" placeholder="Enter your bet..." />
+      <validator const-field-name="amount" prop-errors="bet.errors"></validator>
     </div>
     <button click="place">Bet</button>
-    
-    <error-list prop-errors="bet.errors"></error-list>
   </div>
 </pelela>

--- a/examples/nested-prop-component/src/bet.pelela
+++ b/examples/nested-prop-component/src/bet.pelela
@@ -1,0 +1,12 @@
+<pelela view-model="Bet">
+  <div class="container">
+    <h1>Place Bet</h1>
+    <div class="form-group">
+      <label for="amount">Amount:</label>
+      <input id="amount" type="number" bind-value="bet.amount" placeholder="Enter your bet..." />
+    </div>
+    <button click="place">Bet</button>
+    
+    <error-list prop-errors="bet.errors"></error-list>
+  </div>
+</pelela>

--- a/examples/nested-prop-component/src/bet.ts
+++ b/examples/nested-prop-component/src/bet.ts
@@ -1,0 +1,16 @@
+import { BetModel } from './betModel'
+
+export class Bet {
+  bet = new BetModel()
+  placed = false
+
+  place() {
+    if (this.bet.validate()) {
+      this.placed = true
+      console.log('Bet placed:', this.bet.amount)
+    } else {
+      this.placed = false
+      console.log('Bet errors:', this.bet.errors)
+    }
+  }
+}

--- a/examples/nested-prop-component/src/betModel.ts
+++ b/examples/nested-prop-component/src/betModel.ts
@@ -1,10 +1,7 @@
-type ValidationError = {
-  fieldName: string
-  errorMessage: string
-}
+import type { ValidationError } from './validationError'
 
 export class BetModel {
-  date: Date | null = null
+  date: string = ''
   amount = ''
   errors: ValidationError[] = []
 

--- a/examples/nested-prop-component/src/betModel.ts
+++ b/examples/nested-prop-component/src/betModel.ts
@@ -3,11 +3,14 @@ export class BetModel {
   errors: string[] = []
 
   validate() {
-    this.errors.length = 0 // clear errors
-    if (!this.amount) {
+    this.errors.length = 0
+    if (this.amount) {
+      const amountValue = Number(this.amount)
+      if (!Number.isFinite(amountValue) || amountValue <= 0) {
+        this.errors.push('Amount must be greater than zero')
+      }
+    } else {
       this.errors.push('You must enter a bet amount')
-    } else if (Number(this.amount) <= 0) {
-      this.errors.push('Amount must be greater than zero')
     }
     return this.errors.length === 0
   }

--- a/examples/nested-prop-component/src/betModel.ts
+++ b/examples/nested-prop-component/src/betModel.ts
@@ -1,0 +1,14 @@
+export class BetModel {
+  amount = ''
+  errors: string[] = []
+
+  validate() {
+    this.errors.length = 0 // clear errors
+    if (!this.amount) {
+      this.errors.push('You must enter a bet amount')
+    } else if (Number(this.amount) <= 0) {
+      this.errors.push('Amount must be greater than zero')
+    }
+    return this.errors.length === 0
+  }
+}

--- a/examples/nested-prop-component/src/betModel.ts
+++ b/examples/nested-prop-component/src/betModel.ts
@@ -1,16 +1,35 @@
+type ValidationError = {
+  fieldName: string
+  errorMessage: string
+}
+
 export class BetModel {
+  date: Date | null = null
   amount = ''
-  errors: string[] = []
+  errors: ValidationError[] = []
 
   validate() {
     this.errors.length = 0
+    if (!this.date) {
+      this.errors.push({
+        fieldName: 'date',
+        errorMessage: 'Date is required',
+      })
+    }
+
     if (this.amount) {
       const amountValue = Number(this.amount)
       if (!Number.isFinite(amountValue) || amountValue <= 0) {
-        this.errors.push('Amount must be greater than zero')
+        this.errors.push({
+          fieldName: 'amount',
+          errorMessage: 'Amount must be greater than zero',
+        })
       }
     } else {
-      this.errors.push('You must enter a bet amount')
+      this.errors.push({
+        fieldName: 'amount',
+        errorMessage: 'You must enter a bet amount',
+      })
     }
     return this.errors.length === 0
   }

--- a/examples/nested-prop-component/src/error-list.pelela
+++ b/examples/nested-prop-component/src/error-list.pelela
@@ -1,0 +1,7 @@
+<pelela view-model="ErrorList">
+  <ul class="error-list" if="errors.length">
+    <li for-each="error of errors">
+      <span bind-content="error"></span>
+    </li>
+  </ul>
+</pelela>

--- a/examples/nested-prop-component/src/error-list.pelela
+++ b/examples/nested-prop-component/src/error-list.pelela
@@ -1,7 +1,0 @@
-<pelela view-model="ErrorList">
-  <ul class="error-list" if="errors.length">
-    <li for-each="error of errors">
-      <span bind-content="error"></span>
-    </li>
-  </ul>
-</pelela>

--- a/examples/nested-prop-component/src/error-list.ts
+++ b/examples/nested-prop-component/src/error-list.ts
@@ -1,3 +1,0 @@
-export class ErrorList {
-  errors: string[] = []
-}

--- a/examples/nested-prop-component/src/error-list.ts
+++ b/examples/nested-prop-component/src/error-list.ts
@@ -1,0 +1,3 @@
+export class ErrorList {
+  errors: string[] = []
+}

--- a/examples/nested-prop-component/src/styles.css
+++ b/examples/nested-prop-component/src/styles.css
@@ -1,0 +1,93 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  margin: 0;
+  background-color: #f7f9fc;
+  color: #333;
+}
+
+.container {
+  max-width: 400px;
+  margin: 60px auto;
+  padding: 30px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.05);
+}
+
+h1 {
+  margin-top: 0;
+  color: #1a1a1a;
+  font-size: 24px;
+  text-align: center;
+  margin-bottom: 25px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: #4a5568;
+}
+
+input {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 16px;
+  box-sizing: border-box;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+input:focus {
+  outline: none;
+  border-color: #0066ff;
+  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.1);
+}
+
+button {
+  width: 100%;
+  padding: 14px;
+  background: #0066ff;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+button:hover {
+  background: #0052cc;
+}
+
+.error-list {
+  margin-top: 20px;
+  padding: 15px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #b91c1c;
+  list-style-type: none;
+}
+
+.error-list li {
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+}
+
+.error-list li::before {
+  content: "⚠️";
+  margin-right: 8px;
+}
+
+.error-list li:last-child {
+  margin-bottom: 0;
+}

--- a/examples/nested-prop-component/src/validationError.ts
+++ b/examples/nested-prop-component/src/validationError.ts
@@ -1,0 +1,4 @@
+export type ValidationError = {
+  fieldName: string
+  errorMessage: string
+}

--- a/examples/nested-prop-component/src/validator.pelela
+++ b/examples/nested-prop-component/src/validator.pelela
@@ -1,0 +1,7 @@
+<pelela view-model="Validator">
+  <ul class="error-list" if="filteredErrors.length">
+    <li for-each="error of filteredErrors">
+      <span bind-content="error.errorMessage"></span>
+    </li>
+  </ul>
+</pelela>

--- a/examples/nested-prop-component/src/validator.ts
+++ b/examples/nested-prop-component/src/validator.ts
@@ -1,0 +1,13 @@
+type ValidationError = {
+  fieldName: string
+  errorMessage: string
+}
+
+export class Validator {
+  fieldName = ''
+  errors: ValidationError[] = []
+
+  get filteredErrors(): ValidationError[] {
+    return this.errors.filter((error) => error.fieldName === this.fieldName)
+  }
+}

--- a/examples/nested-prop-component/src/validator.ts
+++ b/examples/nested-prop-component/src/validator.ts
@@ -1,7 +1,4 @@
-type ValidationError = {
-  fieldName: string
-  errorMessage: string
-}
+import type { ValidationError } from './validationError'
 
 export class Validator {
   fieldName = ''

--- a/examples/nested-prop-component/vite.config.ts
+++ b/examples/nested-prop-component/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import { pelelajsPlugin } from 'vite-plugin-pelelajs'
+
+export default defineConfig({
+  plugins: [pelelajsPlugin()],
+})

--- a/examples/routing/src/detail.pelela
+++ b/examples/routing/src/detail.pelela
@@ -1,5 +1,6 @@
 <pelela view-model="Detail">
   <h1>Detalle de Usuario</h1>
+  <img bind-src="avatarUrl" alt="Avatar del usuario" style="width: 100px; height: 100px; border-radius: 50%;" />
   <p>Estás viendo el detalle del ID: <strong bind-content="id"></strong></p>
   <p>Nombre recuperado por Query Params: <strong bind-content="name"></strong></p>
   

--- a/examples/routing/src/detail.pelela
+++ b/examples/routing/src/detail.pelela
@@ -3,6 +3,7 @@
   <img bind-src="avatarUrl" alt="Avatar del usuario" style="width: 100px; height: 100px; border-radius: 50%;" />
   <p>Estás viendo el detalle del ID: <strong bind-content="id"></strong></p>
   <p>Nombre recuperado por Query Params: <strong bind-content="name"></strong></p>
+  <p>Pokemon favorito: <strong bind-content="favoritePokemonName"></strong></p>
   
   <br />
   <button click="goBack">Volver al inicio</button>

--- a/examples/routing/src/detail.ts
+++ b/examples/routing/src/detail.ts
@@ -3,11 +3,13 @@ import { router } from 'pelelajs'
 export class Detail {
   id = ''
   name = ''
+  avatarUrl = ''
 
   constructor() {
     // Obtenemos los parámetros dinámicos de la ruta (e.g., /users/:id)
     const { id } = router.urlParameters()
     this.id = id
+    this.avatarUrl = `https://api.dicebear.com/7.x/avataaars/svg?seed=${id}`
 
     // Obtenemos los query parameters (e.g., ?name=Leon)
     const { name } = router.searchParameters()

--- a/examples/routing/src/detail.ts
+++ b/examples/routing/src/detail.ts
@@ -4,6 +4,7 @@ export class Detail {
   id = ''
   name = ''
   avatarUrl = ''
+  favoritePokemonName = 'Cargando...'
 
   constructor() {
     // Obtenemos los parámetros dinámicos de la ruta (e.g., /users/:id)
@@ -14,6 +15,21 @@ export class Detail {
     // Obtenemos los query parameters (e.g., ?name=Leon)
     const { name } = router.searchParameters()
     this.name = name || 'Usuario Desconocido'
+  }
+
+  async initialize() {
+    try {
+      const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${this.id}/`)
+      if (response.ok) {
+        const data = await response.json()
+        this.favoritePokemonName = data.name
+      } else {
+        this.favoritePokemonName = 'No tiene pokemon favorito'
+      }
+    } catch (error) {
+      console.error('Error fetching pokemon:', error)
+      this.favoritePokemonName = 'Error al cargar pokemon'
+    }
   }
 
   goBack() {

--- a/examples/routing/src/home.ts
+++ b/examples/routing/src/home.ts
@@ -8,8 +8,8 @@ export class Home {
   title = 'Página Principal'
   users: User[] = [
     { id: 1, name: 'Ana García' },
-    { id: 2, name: 'Carlos López' },
-    { id: 3, name: 'María Martínez' },
+    { id: 3, name: 'Carlos López' },
+    { id: 5, name: 'María Martínez' },
   ]
 
   viewUserDetails({ user }: { user: User }) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "chalk": "5.6.2",
     "cli-box": "6.0.11",
     "commander": "12.1.0",
+    "devalue": "^5.1.0",
     "i18next": "^23.7.6"
   },
   "devDependencies": {

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -571,5 +571,93 @@ describe('bindComponent', () => {
       expect(childViewModel.items).toBe(parentViewModel.parentItems)
       expect(childViewModel.config).toBe(parentViewModel.parentConfig)
     })
+
+    it('should skip propagation for unsafe keys (prototype pollution protection)', () => {
+      class ChildVM {
+        value: string = ''
+      }
+
+      const parentViewModel = { __proto__: 'unsafe' }
+      const childViewModel = new ChildVM()
+      const renderChild = vi.fn()
+
+      const bindings: ComponentBinding[] = [
+        {
+          childViewModel: childViewModel as unknown as ViewModel<ChildVM>,
+          mappings: [{ parentKey: '__proto__', childKey: 'value' }],
+          renderChild,
+        },
+      ]
+
+      renderComponentBindings(bindings, parentViewModel, 'value')
+
+      expect(renderChild).not.toHaveBeenCalled()
+    })
+
+    it('should skip rendering child for unsafe keys in mappings', () => {
+      class ChildVM {
+        value: string = ''
+      }
+
+      const parentViewModel = { constructor: 'unsafe' }
+      const childViewModel = new ChildVM()
+      const renderChild = vi.fn()
+
+      const bindings: ComponentBinding[] = [
+        {
+          childViewModel: childViewModel as unknown as ViewModel<ChildVM>,
+          mappings: [{ parentKey: 'constructor', childKey: 'value' }],
+          renderChild,
+        },
+      ]
+
+      renderComponentBindings(bindings, parentViewModel, 'value')
+
+      expect(renderChild).not.toHaveBeenCalled()
+    })
+
+    it('should propagate changes from child to parent with link bindings', () => {
+      class ChildVM {
+        name: string = ''
+      }
+
+      const parentViewModel = { childName: '' }
+      const childViewModel = new ChildVM()
+      const renderChild = vi.fn()
+
+      const bindings: ComponentBinding[] = [
+        {
+          childViewModel: childViewModel as unknown as ViewModel<ChildVM>,
+          mappings: [{ parentKey: 'childName', childKey: 'name' }],
+          renderChild,
+        },
+      ]
+
+      renderComponentBindings(bindings, parentViewModel, 'name')
+
+      expect(parentViewModel.childName).toBe('')
+    })
+
+    it('should render buffered paths after setupBindings assigns renderChild', () => {
+      class ChildVM {
+        value: string = ''
+      }
+
+      const parentViewModel = { value: 'test' }
+      const childViewModel = new ChildVM()
+      const renderChild = vi.fn()
+
+      const bindings: ComponentBinding[] = [
+        {
+          childViewModel: childViewModel as unknown as ViewModel<ChildVM>,
+          mappings: [{ parentKey: 'value', childKey: 'value' }],
+          renderChild,
+        },
+      ]
+
+      renderComponentBindings(bindings, parentViewModel, 'value')
+
+      expect(renderChild).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -22,6 +22,135 @@ describe('bindComponent', () => {
     clearComponentRegistry()
   })
 
+  describe('nested properties reactivity', () => {
+    it('should initialize child component with a nested parent property path (prop-errors="bet.errors")', () => {
+      class ChildVM {
+        errors: string[] = []
+      }
+      defineComponent(
+        'error-list',
+        ChildVM,
+        '<component view-model="ChildVM"><span bind-content="errors"></span></component>',
+      )
+
+      container.innerHTML = '<error-list prop-errors="bet.errors"></error-list>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {
+            errors: ['error1'],
+          },
+        },
+        () => {},
+      )
+
+      const bindings = setupComponentBindings(container, parentVM)
+
+      expect(bindings).toHaveLength(1)
+      const childVM = bindings[0].childViewModel as unknown as ChildVM
+      expect(childVM.errors).toEqual(['error1'])
+    })
+
+    it('should re-render child component when nested array prop is mutated via push()', () => {
+      class ChildVM {
+        errors: string[] = []
+      }
+      defineComponent('error-list', ChildVM, '<component view-model="ChildVM"></component>')
+
+      container.innerHTML = '<error-list prop-errors="bet.errors"></error-list>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {
+            errors: [] as string[],
+          },
+        },
+        (path) => {
+          render(path)
+        },
+      )
+
+      const render = setupBindings(container, parentVM)
+
+      const childEl = container.querySelector('error-list') as PelelaElement<ChildVM>
+      const childVM = childEl.__pelelaViewModel
+
+      expect(childVM.errors).toEqual([])
+
+      parentVM.bet.errors.push('Debe ingresar monto')
+
+      expect(childVM.errors).toEqual(['Debe ingresar monto'])
+    })
+
+    it('should re-render child component when nested array prop is cleared via length = 0', () => {
+      class ChildVM {
+        errors: string[] = []
+      }
+      defineComponent('error-list', ChildVM, '<component view-model="ChildVM"></component>')
+
+      container.innerHTML = '<error-list prop-errors="bet.errors"></error-list>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {
+            errors: ['Error 1', 'Error 2'] as string[],
+          },
+        },
+        (path) => {
+          render(path)
+        },
+      )
+
+      const render = setupBindings(container, parentVM)
+
+      const childEl = container.querySelector('error-list') as PelelaElement<ChildVM>
+      const childVM = childEl.__pelelaViewModel
+
+      expect(childVM.errors).toEqual(['Error 1', 'Error 2'])
+
+      parentVM.bet.errors.length = 0
+
+      expect(childVM.errors).toEqual([])
+    })
+
+    it('should re-render child DOM when nested array prop is mutated via push()', () => {
+      class ChildVM {
+        errors: string[] = []
+      }
+      defineComponent(
+        'error-list',
+        ChildVM,
+        '<component view-model="ChildVM"><ul><li for-each="error of errors"><span bind-content="error"></span></li></ul></component>',
+      )
+
+      container.innerHTML = '<error-list prop-errors="bet.errors"></error-list>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {
+            errors: [] as string[],
+          },
+        },
+        (path) => {
+          render(path)
+        },
+      )
+
+      const render = setupBindings(container, parentVM)
+
+      const childEl = container.querySelector('error-list') as PelelaElement<ChildVM>
+      const listItems = childEl.querySelectorAll('li')
+
+      expect(listItems.length).toBe(0)
+
+      parentVM.bet.errors.push('Error 1')
+
+      const updatedListItems = childEl.querySelectorAll('li')
+      expect(updatedListItems.length).toBe(1)
+      expect(updatedListItems[0].textContent).toBe('Error 1')
+    })
+  })
+
   it('should initialize component with parent properties', () => {
     class ChildVM {
       message = ''

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -330,6 +330,31 @@ describe('bindComponent', () => {
     expect(bindings[0].mappings[0].parentKey).toBe('parentVal')
   })
 
+  it('should call initialize() on child component after setup', () => {
+    const initSpy = vi.fn()
+    class ChildVM {
+      message = 'Initial'
+      initialize() {
+        initSpy()
+        this.message = 'Initialized'
+      }
+    }
+    defineComponent(
+      'init-child',
+      ChildVM,
+      '<component view-model="ChildVM"><span bind-content="message"></span></component>',
+    )
+
+    container.innerHTML = '<init-child></init-child>'
+
+    const parentVM = createReactiveViewModel({}, () => {})
+    setupComponentBindings(container, parentVM)
+
+    expect(initSpy).toHaveBeenCalled()
+    const span = container.querySelector('span')!
+    expect(span.innerHTML).toBe('Initialized')
+  })
+
   describe('prop-* prefix validation', () => {
     it('should throw error when component attribute lacks prop-* or link-* prefix', () => {
       class ChildVM {

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -376,50 +376,6 @@ describe('bindComponent', () => {
       expect(bindings[0].mappings[0].parentKey).toBe('parentValue')
     })
 
-    it('should accept const-* prefix for string constants without reactive mappings', () => {
-      class ChildVM {
-        message = ''
-      }
-      defineComponent(
-        'test-comp',
-        ChildVM,
-        '<component view-model="ChildVM"><span bind-content="message"></span></component>',
-      )
-
-      container.innerHTML = '<test-comp const-message="Hello"></test-comp>'
-
-      const parentVM = createReactiveViewModel({}, () => {})
-      const bindings = setupComponentBindings(container, parentVM)
-
-      const childVM = bindings[0].childViewModel as unknown as ChildVM
-
-      expect(childVM.message).toBe('Hello')
-      expect(bindings).toHaveLength(1)
-      expect(bindings[0].mappings).toEqual([])
-    })
-
-    it('should accept const-* prefix for number constants without reactive mappings', () => {
-      class ChildVM {
-        count = 0
-      }
-      defineComponent(
-        'test-comp',
-        ChildVM,
-        '<component view-model="ChildVM"><span bind-content="count"></span></component>',
-      )
-
-      container.innerHTML = '<test-comp const-count="42"></test-comp>'
-
-      const parentVM = createReactiveViewModel({}, () => {})
-      const bindings = setupComponentBindings(container, parentVM)
-
-      const childVM = bindings[0].childViewModel as unknown as ChildVM
-
-      expect(childVM.count).toBe(42)
-      expect(bindings).toHaveLength(1)
-      expect(bindings[0].mappings).toEqual([])
-    })
-
     it('should accept mix of prop-* and link-* prefixes', () => {
       class ChildVM {
         oneWay = ''
@@ -469,6 +425,102 @@ describe('bindComponent', () => {
           parentKey: 'nonExistentProperty',
         }),
       )
+    })
+
+    it('should throw error when a nested parent property segment does not exist (bet.errors)', () => {
+      class ChildVM {
+        errors = []
+      }
+      defineComponent('test-comp', ChildVM, '<component view-model="ChildVM"></component>')
+
+      container.innerHTML = '<test-comp prop-errors="bet.errors"></error-list>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {},
+        },
+        () => {},
+      )
+
+      expect(() => {
+        setupComponentBindings(container, parentVM)
+      }).toThrow(
+        t('errors.compiler.missingParentProperty', {
+          tag: 'test-comp',
+          parentKey: 'bet.errors',
+        }),
+      )
+    })
+
+    it('should throw error when an intermediate nested property segment does not exist (bet.profile.name)', () => {
+      class ChildVM {
+        name = ''
+      }
+      defineComponent('test-comp', ChildVM, '<component view-model="ChildVM"></component>')
+
+      container.innerHTML = '<test-comp prop-name="bet.profile.name"></test-comp>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {},
+        },
+        () => {},
+      )
+
+      expect(() => {
+        setupComponentBindings(container, parentVM)
+      }).toThrow(
+        t('errors.compiler.missingParentProperty', {
+          tag: 'test-comp',
+          parentKey: 'bet.profile',
+        }),
+      )
+    })
+  })
+
+  describe('const-* bindings', () => {
+    it('should accept const-* prefix for string constants without reactive mappings', () => {
+      class ChildVM {
+        message = ''
+      }
+      defineComponent(
+        'test-comp',
+        ChildVM,
+        '<component view-model="ChildVM"><span bind-content="message"></span></component>',
+      )
+
+      container.innerHTML = '<test-comp const-message="Hello"></test-comp>'
+
+      const parentVM = createReactiveViewModel({}, () => {})
+      const bindings = setupComponentBindings(container, parentVM)
+
+      const childVM = bindings[0].childViewModel as unknown as ChildVM
+
+      expect(childVM.message).toBe('Hello')
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].mappings).toEqual([])
+    })
+
+    it('should accept const-* prefix for number constants without reactive mappings', () => {
+      class ChildVM {
+        count = 0
+      }
+      defineComponent(
+        'test-comp',
+        ChildVM,
+        '<component view-model="ChildVM"><span bind-content="count"></span></component>',
+      )
+
+      container.innerHTML = '<test-comp const-count="42"></test-comp>'
+
+      const parentVM = createReactiveViewModel({}, () => {})
+      const bindings = setupComponentBindings(container, parentVM)
+
+      const childVM = bindings[0].childViewModel as unknown as ChildVM
+
+      expect(childVM.count).toBe(42)
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].mappings).toEqual([])
     })
   })
 

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initializeI18n, t } from '../commons/i18n'
 import { createReactiveViewModel } from '../reactivity/reactiveProxy'
 import { clearComponentRegistry, defineComponent } from '../registry/componentRegistry'
@@ -148,6 +148,37 @@ describe('bindComponent', () => {
       const updatedListItems = childEl.querySelectorAll('li')
       expect(updatedListItems.length).toBe(1)
       expect(updatedListItems[0].textContent).toBe('Error 1')
+    })
+
+    it('should propagate child changes to a nested parent property path with link-*', () => {
+      class ChildVM {
+        amount = ''
+      }
+      defineComponent('error-list', ChildVM, '<component view-model="ChildVM"></component>')
+
+      container.innerHTML = '<error-list link-amount="bet.amount"></error-list>'
+
+      const parentVM = createReactiveViewModel(
+        {
+          bet: {
+            amount: '10',
+          },
+        },
+        (path) => {
+          render(path)
+        },
+      )
+
+      const render = setupBindings(container, parentVM)
+
+      const childEl = container.querySelector('error-list') as PelelaElement<ChildVM>
+      const childVM = childEl.__pelelaViewModel
+
+      expect(childVM.amount).toBe('10')
+
+      childVM.amount = '20'
+
+      expect(parentVM.bet.amount).toBe('20')
     })
   })
 
@@ -398,6 +429,64 @@ describe('bindComponent', () => {
   })
 
   describe('renderComponentBindings', () => {
+    it('should skip child render for object props on initial render when references match', () => {
+      const boundParentKey = 'parentConfig'
+      const boundChildKey = 'config'
+
+      class ChildVM {
+        config: Record<string, unknown> = {}
+      }
+
+      const parentViewModel = {
+        parentConfig: { value: 'test' } as Record<string, unknown>,
+      }
+      const childViewModel = new ChildVM()
+      childViewModel.config = parentViewModel.parentConfig
+      const renderChild = vi.fn()
+
+      const bindings: ComponentBinding[] = [
+        {
+          childViewModel: childViewModel as unknown as ViewModel<ChildVM>,
+          mappings: [{ parentKey: boundParentKey, childKey: boundChildKey }],
+          renderChild,
+        },
+      ]
+
+      renderComponentBindings(bindings, parentViewModel)
+
+      expect(renderChild).not.toHaveBeenCalled()
+    })
+
+    it('should skip child render for object props when changedPath does not affect the bound parent path', () => {
+      const boundParentKey = 'parentConfig'
+      const boundChildKey = 'config'
+      const unrelatedChangedPath = 'otherValue'
+
+      class ChildVM {
+        config: Record<string, unknown> = {}
+      }
+
+      const parentViewModel = {
+        parentConfig: { value: 'test' } as Record<string, unknown>,
+        otherValue: 'changed',
+      }
+      const childViewModel = new ChildVM()
+      childViewModel.config = parentViewModel.parentConfig
+      const renderChild = vi.fn()
+
+      const bindings: ComponentBinding[] = [
+        {
+          childViewModel: childViewModel as unknown as ViewModel<ChildVM>,
+          mappings: [{ parentKey: boundParentKey, childKey: boundChildKey }],
+          renderChild,
+        },
+      ]
+
+      renderComponentBindings(bindings, parentViewModel, unrelatedChangedPath)
+
+      expect(renderChild).not.toHaveBeenCalled()
+    })
+
     it('should share object and array props by reference', () => {
       class ChildVM {
         items: string[] = []

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -376,6 +376,50 @@ describe('bindComponent', () => {
       expect(bindings[0].mappings[0].parentKey).toBe('parentValue')
     })
 
+    it('should accept const-* prefix for string constants without reactive mappings', () => {
+      class ChildVM {
+        message = ''
+      }
+      defineComponent(
+        'test-comp',
+        ChildVM,
+        '<component view-model="ChildVM"><span bind-content="message"></span></component>',
+      )
+
+      container.innerHTML = '<test-comp const-message="Hello"></test-comp>'
+
+      const parentVM = createReactiveViewModel({}, () => {})
+      const bindings = setupComponentBindings(container, parentVM)
+
+      const childVM = bindings[0].childViewModel as unknown as ChildVM
+
+      expect(childVM.message).toBe('Hello')
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].mappings).toEqual([])
+    })
+
+    it('should accept const-* prefix for number constants without reactive mappings', () => {
+      class ChildVM {
+        count = 0
+      }
+      defineComponent(
+        'test-comp',
+        ChildVM,
+        '<component view-model="ChildVM"><span bind-content="count"></span></component>',
+      )
+
+      container.innerHTML = '<test-comp const-count="42"></test-comp>'
+
+      const parentVM = createReactiveViewModel({}, () => {})
+      const bindings = setupComponentBindings(container, parentVM)
+
+      const childVM = bindings[0].childViewModel as unknown as ChildVM
+
+      expect(childVM.count).toBe(42)
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].mappings).toEqual([])
+    })
+
     it('should accept mix of prop-* and link-* prefixes', () => {
       class ChildVM {
         oneWay = ''

--- a/packages/core/src/bindings/bindComponent.test.ts
+++ b/packages/core/src/bindings/bindComponent.test.ts
@@ -51,6 +51,40 @@ describe('bindComponent', () => {
       expect(childVM.errors).toEqual(['error1'])
     })
 
+    it('should initialize child component with a dotted parent key provided by a for-each context (item.name)', () => {
+      class ChildVM {
+        name = ''
+      }
+      defineComponent(
+        'test-comp',
+        ChildVM,
+        '<component view-model="ChildVM"><span bind-content="name"></span></component>',
+      )
+
+      container.innerHTML = `
+        <div for-each="item of items">
+          <test-comp prop-name="item.name"></test-comp>
+        </div>
+      `
+
+      const parentVM = createReactiveViewModel(
+        {
+          items: [{ name: 'Alice' }],
+        },
+        () => {},
+      )
+
+      // setupBindings will internally call setupForEachBindings and then renderForEachBindings,
+      // which in turn calls setupComponentBindings for each item's template.
+      setupBindings(container, parentVM)
+
+      const childEl = container.querySelector('test-comp') as PelelaElement<Record<string, unknown>>
+      const childVM = childEl.__pelelaViewModel
+
+      expect(childVM).toBeDefined()
+      expect(childVM.name).toBe('Alice')
+    })
+
     it('should re-render child component when nested array prop is mutated via push()', () => {
       class ChildVM {
         errors: string[] = []
@@ -427,54 +461,19 @@ describe('bindComponent', () => {
       )
     })
 
-    it('should throw error when a nested parent property segment does not exist (bet.errors)', () => {
-      class ChildVM {
-        errors = []
-      }
-      defineComponent('test-comp', ChildVM, '<component view-model="ChildVM"></component>')
-
-      container.innerHTML = '<test-comp prop-errors="bet.errors"></error-list>'
-
-      const parentVM = createReactiveViewModel(
-        {
-          bet: {},
-        },
-        () => {},
-      )
-
-      expect(() => {
-        setupComponentBindings(container, parentVM)
-      }).toThrow(
-        t('errors.compiler.missingParentProperty', {
-          tag: 'test-comp',
-          parentKey: 'bet.errors',
-        }),
-      )
-    })
-
-    it('should throw error when an intermediate nested property segment does not exist (bet.profile.name)', () => {
+    it('should not throw error when a nested parent property path is missing (lenient validation)', () => {
       class ChildVM {
         name = ''
       }
       defineComponent('test-comp', ChildVM, '<component view-model="ChildVM"></component>')
 
-      container.innerHTML = '<test-comp prop-name="bet.profile.name"></test-comp>'
+      container.innerHTML = '<test-comp prop-name="missing.nested.path"></test-comp>'
 
-      const parentVM = createReactiveViewModel(
-        {
-          bet: {},
-        },
-        () => {},
-      )
+      const parentVM = createReactiveViewModel({}, () => {})
 
       expect(() => {
         setupComponentBindings(container, parentVM)
-      }).toThrow(
-        t('errors.compiler.missingParentProperty', {
-          tag: 'test-comp',
-          parentKey: 'bet.profile',
-        }),
-      )
+      }).not.toThrow()
     })
   })
 

--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -1,4 +1,5 @@
 import {
+  CONST_PREFIX,
   isPelelaRootTag,
   isStandardHtmlTag,
   isValidComponentAttribute,
@@ -24,6 +25,18 @@ function isProps(attr: Attr): boolean {
   return attr.name.startsWith(PROP_PREFIX)
 }
 
+function isConst(attr: Attr): boolean {
+  return attr.name.startsWith(CONST_PREFIX)
+}
+
+function isNumberConstant(value: string): boolean {
+  return value.trim() !== '' && !Number.isNaN(Number(value))
+}
+
+function parseConstant(value: string): string | number {
+  return isNumberConstant(value) ? Number(value) : value
+}
+
 function extractLinkBindings(
   attributes: NamedNodeMap,
 ): Array<{ parentKey: string; childKey: string }> {
@@ -43,6 +56,17 @@ function extractOneWayBindings(
     .map((attr) => ({
       childKey: toCamelCase(attr.name.substring(PROP_PREFIX.length)),
       parentKey: attr.value,
+    }))
+}
+
+function extractConstantBindings(
+  attributes: NamedNodeMap,
+): Array<{ childKey: string; value: string | number }> {
+  return Array.from(attributes)
+    .filter(isConst)
+    .map((attr) => ({
+      childKey: toCamelCase(attr.name.substring(CONST_PREFIX.length)),
+      value: parseConstant(attr.value),
     }))
 }
 
@@ -118,9 +142,22 @@ export function setupComponentBindings<T extends object>(
     assertOnlyValidComponentAttributes(element)
 
     const instance = new componentDef.creator() as Record<string, unknown>
+    const constantBindings = extractConstantBindings(element.attributes)
     const linkBindings = extractLinkBindings(element.attributes)
     const oneWayBindings = extractOneWayBindings(element.attributes)
     const allMappings = [...linkBindings, ...oneWayBindings]
+
+    constantBindings.forEach(({ childKey, value }) => {
+      if (isUnsafeKey(childKey)) {
+        throw new Error(
+          t('errors.security.prototypePollution', {
+            keys: childKey,
+          }),
+        )
+      }
+
+      instance[childKey] = value
+    })
 
     allMappings.forEach(({ parentKey, childKey }) => {
       if (isUnsafeKey(parentKey) || isUnsafeKey(childKey)) {

--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -169,22 +169,19 @@ export function setupComponentBindings<T extends object>(
       }
 
       const pathSegments = parentKey.split('.')
-      let current: unknown = parentViewModel
-      for (const segment of pathSegments) {
+      const parentValue = pathSegments.reduce((current, segment, index) => {
         if (!isObject(current) || !hasProperty(current as object, segment)) {
           throw new Error(
             t('errors.compiler.missingParentProperty', {
               tag: element.tagName.toLowerCase(),
-              parentKey,
+              parentKey: pathSegments.slice(0, index + 1).join('.'),
             }),
           )
         }
-        current = (current as Record<string, unknown>)[segment]
-      }
+        return (current as Record<string, unknown>)[segment]
+      }, parentViewModel as unknown)
 
-      instance[childKey] = parentKey.includes('.')
-        ? getNestedProperty(parentViewModel, parentKey)
-        : (parentViewModel as Record<string, unknown>)[parentKey]
+      instance[childKey] = parentValue
     })
 
     // Buffer change paths during setup to avoid losing reactive updates

--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -194,6 +194,7 @@ export function setupComponentBindings<T extends object>(
 export function renderComponentBindings<T extends object>(
   bindings: ComponentBinding[],
   parentViewModel: ViewModel<T>,
+  changedPath?: string,
 ): void {
   bindings.forEach((binding) => {
     binding.mappings.forEach(({ parentKey, childKey }) => {
@@ -208,11 +209,22 @@ export function renderComponentBindings<T extends object>(
 
       if (parentValue !== childValue) {
         ;(binding.childViewModel as Record<string, unknown>)[childKey] = parentValue
-        // Force re-render of child when value changes
         binding.renderChild?.(childKey)
-      } else if (isObject(parentValue)) {
+      } else if (
+        isObject(parentValue) &&
+        changedPath !== undefined &&
+        isPathAffected(parentKey, changedPath)
+      ) {
         binding.renderChild?.(childKey)
       }
     })
   })
+}
+
+function isPathAffected(parentKey: string, changedPath: string): boolean {
+  return (
+    changedPath === parentKey ||
+    changedPath.startsWith(`${parentKey}.`) ||
+    changedPath.startsWith(`${parentKey}[`)
+  )
 }

--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -169,8 +169,11 @@ export function setupComponentBindings<T extends object>(
       }
 
       const pathSegments = parentKey.split('.')
+      const isNested = pathSegments.length > 1
       const parentValue = pathSegments.reduce((current, segment, index) => {
         if (!isObject(current) || !hasProperty(current as object, segment)) {
+          if (isNested) return undefined
+
           throw new Error(
             t('errors.compiler.missingParentProperty', {
               tag: element.tagName.toLowerCase(),

--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -5,13 +5,14 @@ import {
   LINK_PREFIX,
   PROP_PREFIX,
 } from '../commons/dom'
-import { findAllElements, toCamelCase, unwrapTemplate } from '../commons/helpers'
+import { findAllElements, isObject, toCamelCase, unwrapTemplate } from '../commons/helpers'
 import { t } from '../commons/i18n'
 import { hasProperty, isUnsafeKey, sanitizeHTML } from '../commons/sanitization'
 import { UnknownComponentError } from '../errors'
 import { createReactiveViewModel } from '../reactivity/reactiveProxy'
 import { getComponentByTag, getRegisteredTags } from '../registry/componentRegistry'
 import type { PelelaElement } from '../types'
+import { getNestedProperty, setNestedProperty } from './nestedProperties'
 import { setupBindings } from './setupBindings'
 import type { ComponentBinding, ViewModel } from './types'
 
@@ -74,6 +75,25 @@ function validateTags(root: HTMLElement, registeredTags: string[]): void {
   })
 }
 
+function handleLinkPropagation(
+  linkBindings: Array<{ parentKey: string; childKey: string }>,
+  parentViewModel: ViewModel<object>,
+  reactiveInstance: ViewModel<object>,
+  changedPath: string,
+): void {
+  const linkBinding = linkBindings.find((binding) => binding.childKey === changedPath)
+  if (!linkBinding) return
+
+  if (isUnsafeKey(linkBinding.parentKey)) return
+
+  if (linkBinding.parentKey.includes('.')) {
+    setNestedProperty(parentViewModel, linkBinding.parentKey, reactiveInstance[changedPath])
+  } else {
+    ;(parentViewModel as Record<string, unknown>)[linkBinding.parentKey] =
+      reactiveInstance[changedPath]
+  }
+}
+
 export function setupComponentBindings<T extends object>(
   root: HTMLElement,
   parentViewModel: ViewModel<T>,
@@ -111,33 +131,36 @@ export function setupComponentBindings<T extends object>(
         )
       }
 
-      if (!parentKey.includes('.') && !hasProperty(parentViewModel, parentKey)) {
-        throw new Error(
-          t('errors.compiler.missingParentProperty', {
-            tag: element.tagName.toLowerCase(),
-            parentKey,
-          }),
-        )
+      const pathSegments = parentKey.split('.')
+      let current: unknown = parentViewModel
+      for (const segment of pathSegments) {
+        if (!isObject(current) || !hasProperty(current as object, segment)) {
+          throw new Error(
+            t('errors.compiler.missingParentProperty', {
+              tag: element.tagName.toLowerCase(),
+              parentKey,
+            }),
+          )
+        }
+        current = (current as Record<string, unknown>)[segment]
       }
-      instance[childKey] = (parentViewModel as Record<string, unknown>)[parentKey]
+
+      instance[childKey] = parentKey.includes('.')
+        ? getNestedProperty(parentViewModel, parentKey)
+        : (parentViewModel as Record<string, unknown>)[parentKey]
     })
 
     // Buffer change paths during setup to avoid losing reactive updates
     const bufferedPaths: string[] = []
-    let isSetupComplete = false
+    const isSetupComplete = { value: false }
     let renderChild: (changedPath?: string) => void = () => {}
     const reactiveInstance = createReactiveViewModel(instance, (changedPath: string) => {
       if (isUnsafeKey(changedPath)) return
 
-      const linkBinding = linkBindings.find((binding) => binding.childKey === changedPath)
-      if (linkBinding) {
-        if (isUnsafeKey(linkBinding.parentKey)) return
-        ;(parentViewModel as Record<string, unknown>)[linkBinding.parentKey] =
-          reactiveInstance[changedPath]
-      }
+      handleLinkPropagation(linkBindings, parentViewModel, reactiveInstance, changedPath)
 
       // Buffer changes during setup, render directly after setup
-      if (isSetupComplete) {
+      if (isSetupComplete.value) {
         renderChild(changedPath)
       } else {
         bufferedPaths.push(changedPath)
@@ -151,7 +174,7 @@ export function setupComponentBindings<T extends object>(
     // The component tag's own 'if' belongs to the parent's view model.
     // Pass skipRootIf so the child binding setup doesn't try to validate it.
     renderChild = setupBindings(element, reactiveInstance, { skipRootIf: true })
-    isSetupComplete = true
+    isSetupComplete.value = true
 
     // Flush buffered changes after setupBindings assigns renderChild
     bufferedPaths.forEach((path) => {
@@ -161,6 +184,7 @@ export function setupComponentBindings<T extends object>(
     bindings.push({
       childViewModel: reactiveInstance,
       mappings: allMappings,
+      renderChild,
     })
   })
 
@@ -177,11 +201,17 @@ export function renderComponentBindings<T extends object>(
         return
       }
 
-      const parentValue = (parentViewModel as Record<string, unknown>)[parentKey]
+      const parentValue = parentKey.includes('.')
+        ? getNestedProperty(parentViewModel, parentKey)
+        : (parentViewModel as Record<string, unknown>)[parentKey]
       const childValue = (binding.childViewModel as Record<string, unknown>)[childKey]
 
       if (parentValue !== childValue) {
         ;(binding.childViewModel as Record<string, unknown>)[childKey] = parentValue
+        // Force re-render of child when value changes
+        binding.renderChild?.(childKey)
+      } else if (isObject(parentValue)) {
+        binding.renderChild?.(childKey)
       }
     })
   })

--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -223,6 +223,10 @@ export function setupComponentBindings<T extends object>(
       mappings: allMappings,
       renderChild,
     })
+
+    if (typeof reactiveInstance.initialize === 'function') {
+      reactiveInstance.initialize()
+    }
   })
 
   return bindings

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -976,4 +976,84 @@ describe('bindForEach', () => {
       }).toThrow(InvalidBindingSyntaxError)
     })
   })
+
+  describe('Issue #113 - nested paths and option value', () => {
+    it('should support nested paths in for-each collection', () => {
+      container.innerHTML = `
+        <div>
+          <span for-each="value of parent.nested.values" bind-content="value"></span>
+        </div>
+      `
+
+      const viewModel = {
+        parent: {
+          nested: {
+            values: [10, 20, 30],
+          },
+        },
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const spans = container.querySelectorAll('span')
+      expect(spans).toHaveLength(3)
+      expect(spans[0].textContent).toBe('10')
+      expect(spans[1].textContent).toBe('20')
+      expect(spans[2].textContent).toBe('30')
+    })
+
+    it('should react to changes in nested for-each collection', () => {
+      container.innerHTML = `
+        <div>
+          <span for-each="value of parent.nested.values" bind-content="value"></span>
+        </div>
+      `
+
+      const viewModel = {
+        parent: {
+          nested: {
+            values: [10, 20],
+          },
+        },
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      let spans = container.querySelectorAll('span')
+      expect(spans).toHaveLength(2)
+
+      viewModel.parent.nested.values.push(30)
+      renderForEachBindings(bindings, viewModel)
+
+      spans = container.querySelectorAll('span')
+      expect(spans).toHaveLength(3)
+    })
+
+    it('should set option value to the for-each item object', () => {
+      container.innerHTML = `
+        <select>
+          <option for-each="type of types" bind-content="type.description"></option>
+        </select>
+      `
+
+      const viewModel = {
+        types: [
+          { description: 'Type A', value: 1 },
+          { description: 'Type B', value: 2 },
+        ],
+      }
+
+      const bindings = setupForEachBindings(container, viewModel)
+      renderForEachBindings(bindings, viewModel)
+
+      const options = container.querySelectorAll('option')
+      expect(options).toHaveLength(2)
+      expect(options[0].textContent).toBe('Type A')
+      expect(options[0].value).toBe('[{"description":1,"value":2},"Type A",1]')
+      expect(options[1].textContent).toBe('Type B')
+      expect(options[1].value).toBe('[{"description":1,"value":2},"Type B",2]')
+    })
+  })
 })

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -1055,5 +1055,89 @@ describe('bindForEach', () => {
       expect(options[1].textContent).toBe('Type B')
       expect(options[1].value).toBe('[{"description":1,"value":2},"Type B",2]')
     })
+
+    it('should set option value to string when item is not object', () => {
+      container.innerHTML = `
+        <select bind-value="selected">
+          <option for-each="item of values" bind-content="item"></option>
+        </select>
+      `
+      const viewModel = { values: [1, 2, 3], selected: null }
+
+      setupBindings(container, viewModel)
+
+      const options = container.querySelectorAll('option')
+      expect(options).toHaveLength(3)
+      expect(options[0].value).toBe('1')
+      expect(options[1].value).toBe('2')
+      expect(options[2].value).toBe('3')
+    })
+
+    it('should access nested properties of item in for-each', () => {
+      container.innerHTML = `
+        <div for-each="item of items">
+          <span bind-content="item.name"></span>
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Item 1' }, { name: 'Item 2' }] }
+
+      setupBindings(container, viewModel)
+
+      const spans = container.querySelectorAll('span')
+      expect(spans).toHaveLength(2)
+      expect(spans[0].textContent).toBe('Item 1')
+      expect(spans[1].textContent).toBe('Item 2')
+    })
+
+    it('should access deeply nested properties of item in for-each', () => {
+      container.innerHTML = `
+        <div for-each="item of items">
+          <span bind-content="item.details.name"></span>
+        </div>
+      `
+      const viewModel = {
+        items: [{ details: { name: 'Item 1' } }, { details: { name: 'Item 2' } }],
+      }
+
+      setupBindings(container, viewModel)
+
+      const spans = container.querySelectorAll('span')
+      expect(spans).toHaveLength(2)
+      expect(spans[0].textContent).toBe('Item 1')
+      expect(spans[1].textContent).toBe('Item 2')
+    })
+
+    it('should bind to nested properties of item in for-each', () => {
+      container.innerHTML = `
+        <div for-each="item of items">
+          <input bind-value="item.name" />
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Item 1' }, { name: 'Item 2' }] }
+
+      setupBindings(container, viewModel)
+
+      const inputs = container.querySelectorAll('input')
+      expect(inputs).toHaveLength(2)
+      expect(inputs[0].value).toBe('Item 1')
+      expect(inputs[1].value).toBe('Item 2')
+    })
+
+    it('should update nested properties of item in for-each', () => {
+      container.innerHTML = `
+        <div for-each="item of items">
+          <input bind-value="item.name" />
+        </div>
+      `
+      const viewModel = { items: [{ name: 'Item 1' }, { name: 'Item 2' }] }
+
+      setupBindings(container, viewModel)
+
+      const inputs = container.querySelectorAll('input')
+      inputs[0].value = 'Updated Item 1'
+      inputs[0].dispatchEvent(new Event('input'))
+
+      expect(viewModel.items[0].name).toBe('Updated Item 1')
+    })
   })
 })

--- a/packages/core/src/bindings/bindForEach.test.ts
+++ b/packages/core/src/bindings/bindForEach.test.ts
@@ -924,6 +924,23 @@ describe('bindForEach', () => {
       expect(binding!.extraDependencies).not.toContain('i')
     })
 
+    it('should not produce false positives in dependency normalization when first segment matches as prefix but not exactly', () => {
+      container.innerHTML = `
+        <div for-each="item of userItems">
+          <span bind-content="username"></span>
+        </div>
+      `
+      const viewModel = { userItems: [], username: 'test' }
+      const binding = setupSingleForEachBinding(
+        container.querySelector('[for-each]') as HTMLElement,
+        viewModel,
+      )
+
+      expect(binding).not.toBeNull()
+      expect(binding!.extraDependencies).toContain('username')
+      expect(binding!.extraDependencies).not.toContain('user')
+    })
+
     it('should ignore empty or whitespace-only index attribute', () => {
       container.innerHTML = `
         <div for-each="item of items" index="   ">

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -229,7 +229,8 @@ function extractExtraDependencies(
     )
     .map((propPath) => {
       const collectionFirstSegment = collectionName.split('.')[0]
-      return propPath.startsWith(collectionFirstSegment) ? collectionFirstSegment : propPath
+      const propFirstSegment = propPath.split('.')[0]
+      return propFirstSegment === collectionFirstSegment ? collectionFirstSegment : propPath
     })
 }
 
@@ -242,6 +243,10 @@ export function setupForEachBindings<T extends object>(
   return ownElements
     .map((element) => setupSingleForEachBinding(element, viewModel))
     .filter((binding): binding is ForEachBinding => binding !== null)
+}
+
+function serializeOptionValue(item: unknown): string {
+  return typeof item === 'object' && item !== null ? stringify(item) : String(item)
 }
 
 function createNewElement<T extends object>(
@@ -263,11 +268,7 @@ function createNewElement<T extends object>(
   const render = setupBindingsForElement(element, extendedViewModel)
 
   if (element.tagName === 'OPTION') {
-    if (typeof item === 'object' && item !== null) {
-      ;(element as HTMLOptionElement).value = stringify(item)
-    } else {
-      ;(element as HTMLOptionElement).value = String(item)
-    }
+    ;(element as HTMLOptionElement).value = serializeOptionValue(item)
   }
 
   const lastElement =
@@ -308,12 +309,7 @@ function updateExistingElements(binding: ForEachBinding, collection: unknown[]):
     rendered.indexRef.current = index
 
     if (rendered.element.tagName === 'OPTION') {
-      const item = collection[index]
-      if (typeof item === 'object' && item !== null) {
-        ;(rendered.element as HTMLOptionElement).value = stringify(item)
-      } else {
-        ;(rendered.element as HTMLOptionElement).value = String(item)
-      }
+      ;(rendered.element as HTMLOptionElement).value = serializeOptionValue(collection[index])
     }
 
     rendered.render()

--- a/packages/core/src/bindings/bindForEach.ts
+++ b/packages/core/src/bindings/bindForEach.ts
@@ -1,3 +1,4 @@
+import { stringify } from 'devalue'
 import { LINK_PREFIX, PROP_PREFIX } from '../commons/dom'
 import {
   extractElementSnippet,
@@ -28,7 +29,9 @@ function parseForEachExpression(
   expression: string,
 ): { itemName: string; collectionName: string } | null {
   const identifier = IDENTIFIER_PATTERN.source.replace(/^\^|\$$/g, '')
-  const match = expression.trim().match(new RegExp(`^(${identifier})\\s+of\\s+(${identifier})$`))
+  const match = expression
+    .trim()
+    .match(new RegExp(`^(${identifier})\\s+of\\s+(${identifier}(\\.${identifier})*)$`))
   if (!match) return null
   return { itemName: match[1], collectionName: match[2] }
 }
@@ -119,8 +122,11 @@ export function setupSingleForEachBinding<T extends object>(
   if (indexName && !isValidIdentifier(indexName)) {
     throw new InvalidBindingSyntaxError('index', rawIndexName ?? '', 'valid identifier')
   }
-  assertViewModelProperty(viewModel, collectionName, 'for-each', element)
-  const collection = viewModel[collectionName]
+  const collectionFirstSegment = collectionName.split('.')[0]
+  assertViewModelProperty(viewModel, collectionFirstSegment, 'for-each', element)
+  const collection = collectionName.includes('.')
+    ? getNestedProperty(viewModel, collectionName)
+    : viewModel[collectionName]
   if (!Array.isArray(collection)) {
     throw new InvalidPropertyTypeError({
       propertyName: collectionName,
@@ -221,7 +227,10 @@ function extractExtraDependencies(
     .filter(
       (propPath) => propPath && isExternalDependency(propPath, itemName, collectionName, indexName),
     )
-    .map((propPath) => propPath.split('.')[0])
+    .map((propPath) => {
+      const collectionFirstSegment = collectionName.split('.')[0]
+      return propPath.startsWith(collectionFirstSegment) ? collectionFirstSegment : propPath
+    })
 }
 
 export function setupForEachBindings<T extends object>(
@@ -252,6 +261,15 @@ function createNewElement<T extends object>(
     indexRef,
   })
   const render = setupBindingsForElement(element, extendedViewModel)
+
+  if (element.tagName === 'OPTION') {
+    if (typeof item === 'object' && item !== null) {
+      ;(element as HTMLOptionElement).value = stringify(item)
+    } else {
+      ;(element as HTMLOptionElement).value = String(item)
+    }
+  }
+
   const lastElement =
     binding.renderedElements[binding.renderedElements.length - 1]?.element || binding.placeholder
   binding.renderedElements.push({
@@ -288,6 +306,16 @@ function updateExistingElements(binding: ForEachBinding, collection: unknown[]):
   binding.renderedElements.forEach((rendered, index) => {
     rendered.itemRef.current = collection[index]
     rendered.indexRef.current = index
+
+    if (rendered.element.tagName === 'OPTION') {
+      const item = collection[index]
+      if (typeof item === 'object' && item !== null) {
+        ;(rendered.element as HTMLOptionElement).value = stringify(item)
+      } else {
+        ;(rendered.element as HTMLOptionElement).value = String(item)
+      }
+    }
+
     rendered.render()
   })
 }
@@ -296,7 +324,9 @@ function renderSingleForEachBinding<T extends object>(
   binding: ForEachBinding,
   viewModel: ViewModel<T>,
 ): void {
-  const collection = viewModel[binding.collectionName]
+  const collection = binding.collectionName.includes('.')
+    ? getNestedProperty(viewModel, binding.collectionName)
+    : viewModel[binding.collectionName]
   if (!Array.isArray(collection)) return
   const currentLength = collection.length
   const previousLength = binding.previousLength

--- a/packages/core/src/bindings/bindIf.test.ts
+++ b/packages/core/src/bindings/bindIf.test.ts
@@ -28,6 +28,24 @@ describe('bindIf', () => {
       expect(bindings).toHaveLength(2)
     })
 
+    it('should return null for empty if attribute', () => {
+      container.innerHTML = '<div if=""></div>'
+      const viewModel = {}
+
+      const bindings = setupIfBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(0)
+    })
+
+    it('should return null for whitespace-only if attribute', () => {
+      container.innerHTML = '<div if="   "></div>'
+      const viewModel = {}
+
+      const bindings = setupIfBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(0)
+    })
+
     it('should save original display of element', () => {
       container.innerHTML = '<div if="show" style="display: flex;"></div>'
 

--- a/packages/core/src/bindings/bindIf.test.ts
+++ b/packages/core/src/bindings/bindIf.test.ts
@@ -28,7 +28,7 @@ describe('bindIf', () => {
       expect(bindings).toHaveLength(2)
     })
 
-    it('should return null for empty if attribute', () => {
+    it('should return empty bindings for empty if attribute', () => {
       container.innerHTML = '<div if=""></div>'
       const viewModel = {}
 
@@ -37,7 +37,7 @@ describe('bindIf', () => {
       expect(bindings).toHaveLength(0)
     })
 
-    it('should return null for whitespace-only if attribute', () => {
+    it('should return empty bindings for whitespace-only if attribute', () => {
       container.innerHTML = '<div if="   "></div>'
       const viewModel = {}
 

--- a/packages/core/src/bindings/bindSrc.test.ts
+++ b/packages/core/src/bindings/bindSrc.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PropertyValidationError } from '../errors/index'
+import { testHelpers } from '../test/helpers'
+import { renderSrcBindings, setupSrcBindings } from './bindSrc'
+import type { ViewModel } from './types'
+
+describe('bindSrc', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = testHelpers.createTestContainer()
+  })
+
+  afterEach(() => {
+    testHelpers.cleanupTestContainer(container)
+  })
+
+  describe('setupSrcBindings', () => {
+    it('should collect img elements with bind-src', () => {
+      container.innerHTML = '<img bind-src="imageUrl" />'
+
+      const viewModel = { imageUrl: 'test.png' }
+      const bindings = setupSrcBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(1)
+      expect(bindings[0].propertyName).toBe('imageUrl')
+      expect(bindings[0].element).toBeInstanceOf(HTMLImageElement)
+    })
+
+    it('should throw error if element is not an img', () => {
+      container.innerHTML = '<div bind-src="imageUrl"></div>'
+      const viewModel = { imageUrl: 'test.png' }
+
+      expect(() => {
+        setupSrcBindings(container, viewModel)
+      }).toThrow(
+        /bind-src solo puede usarse en elementos <img>|bind-src can only be used on <img> elements/,
+      )
+    })
+
+    it('should throw error if property does not exist in viewModel', () => {
+      container.innerHTML = '<img bind-src="missing" />'
+      const viewModel = {}
+
+      expect(() => {
+        setupSrcBindings(container, viewModel)
+      }).toThrow(PropertyValidationError)
+    })
+
+    it('should ignore empty bind-src attributes', () => {
+      container.innerHTML = '<img bind-src="" />'
+      const viewModel = { imageUrl: 'test.png' }
+
+      const bindings = setupSrcBindings(container, viewModel)
+      expect(bindings).toHaveLength(0)
+    })
+  })
+
+  describe('renderSrcBindings', () => {
+    it('should update the src attribute of img elements', () => {
+      container.innerHTML = '<img bind-src="imageUrl" />'
+      const viewModel = { imageUrl: 'old.png' }
+      const bindings = setupSrcBindings(container, viewModel)
+
+      viewModel.imageUrl = 'new.png'
+      renderSrcBindings(bindings, viewModel)
+
+      const img = container.querySelector('img')!
+      expect(img.getAttribute('src')).toBe('new.png')
+    })
+
+    it('should handle null and undefined values by removing the src attribute', () => {
+      container.innerHTML = '<img bind-src="imageUrl" />'
+      const viewModel: ViewModel<{ imageUrl: unknown }> = { imageUrl: 'initial.png' }
+      const bindings = setupSrcBindings(container, viewModel)
+
+      viewModel.imageUrl = null
+      renderSrcBindings(bindings, viewModel)
+      expect(container.querySelector('img')!.getAttribute('src')).toBeNull()
+
+      viewModel.imageUrl = undefined
+      renderSrcBindings(bindings, viewModel)
+      expect(container.querySelector('img')!.getAttribute('src')).toBeNull()
+    })
+
+    it('should not update if value has not changed', () => {
+      container.innerHTML = '<img bind-src="imageUrl" src="test.png" />'
+      const viewModel = { imageUrl: 'test.png' }
+      const bindings = setupSrcBindings(container, viewModel)
+
+      const img = container.querySelector('img')!
+      const spy = vi.spyOn(img, 'setAttribute')
+
+      renderSrcBindings(bindings, viewModel)
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/bindings/bindSrc.ts
+++ b/packages/core/src/bindings/bindSrc.ts
@@ -1,0 +1,58 @@
+import { filterOwnElements, findAllElements } from '../commons/helpers'
+import { t } from '../commons/i18n'
+import { assertViewModelProperty } from '../validation/assertViewModelProperty'
+import { getNestedProperty } from './nestedProperties'
+import type { SrcBinding, ViewModel } from './types'
+
+function setupSingleSrcBinding<T extends object>(
+  element: HTMLElement,
+  viewModel: ViewModel<T>,
+): SrcBinding | null {
+  const propertyName = element.getAttribute('bind-src')
+  if (!propertyName?.trim()) return null
+
+  if (!(element instanceof HTMLImageElement)) {
+    throw new Error(t('errors.bindings.srcOnlyForImg', { tag: element.tagName.toLowerCase() }))
+  }
+
+  assertViewModelProperty(viewModel, propertyName, 'bind-src', element)
+
+  return { element, propertyName }
+}
+
+export function setupSrcBindings<T extends object>(
+  root: HTMLElement,
+  viewModel: ViewModel<T>,
+): SrcBinding[] {
+  const elements = findAllElements(root, '[bind-src]')
+  const ownElements = filterOwnElements(elements, root)
+
+  return ownElements
+    .map((element) => setupSingleSrcBinding(element, viewModel))
+    .filter((binding): binding is SrcBinding => binding !== null)
+}
+
+function renderSingleSrcBinding<T extends object>(
+  binding: SrcBinding,
+  viewModel: ViewModel<T>,
+): void {
+  const value = getNestedProperty(viewModel, binding.propertyName)
+  const srcValue = value === undefined || value === null ? '' : String(value)
+
+  if (binding.element.getAttribute('src') !== srcValue) {
+    if (srcValue === '') {
+      binding.element.removeAttribute('src')
+    } else {
+      binding.element.setAttribute('src', srcValue)
+    }
+  }
+}
+
+export function renderSrcBindings<T extends object>(
+  bindings: SrcBinding[],
+  viewModel: ViewModel<T>,
+): void {
+  bindings.forEach((binding) => {
+    renderSingleSrcBinding(binding, viewModel)
+  })
+}

--- a/packages/core/src/bindings/bindStyle.test.ts
+++ b/packages/core/src/bindings/bindStyle.test.ts
@@ -28,7 +28,7 @@ describe('bindStyle', () => {
       expect(bindings).toHaveLength(2)
     })
 
-    it('should return null for empty bind-style attribute', () => {
+    it('should return empty bindings for empty bind-style attribute', () => {
       container.innerHTML = '<div bind-style=""></div>'
       const viewModel = {}
 
@@ -37,7 +37,7 @@ describe('bindStyle', () => {
       expect(bindings).toHaveLength(0)
     })
 
-    it('should return null for whitespace-only bind-style attribute', () => {
+    it('should return empty bindings for whitespace-only bind-style attribute', () => {
       container.innerHTML = '<div bind-style="   "></div>'
       const viewModel = {}
 

--- a/packages/core/src/bindings/bindStyle.test.ts
+++ b/packages/core/src/bindings/bindStyle.test.ts
@@ -28,6 +28,24 @@ describe('bindStyle', () => {
       expect(bindings).toHaveLength(2)
     })
 
+    it('should return null for empty bind-style attribute', () => {
+      container.innerHTML = '<div bind-style=""></div>'
+      const viewModel = {}
+
+      const bindings = setupStyleBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(0)
+    })
+
+    it('should return null for whitespace-only bind-style attribute', () => {
+      container.innerHTML = '<div bind-style="   "></div>'
+      const viewModel = {}
+
+      const bindings = setupStyleBindings(container, viewModel)
+
+      expect(bindings).toHaveLength(0)
+    })
+
     it('should throw error if property does not exist', () => {
       container.innerHTML = '<div bind-style="missing"></div>'
       const viewModel = {}

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -302,6 +302,19 @@ describe('bindValue', () => {
       expect(viewModel.data).toBe('invalid json')
     })
 
+    it('should parse valid devalue strings into objects when current value is object', () => {
+      container.innerHTML = '<input bind-value="data" />'
+      const viewModel = { data: { key: 'initial' } }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = '[{"key":1},"updated"]'
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.data).toEqual({ key: 'updated' })
+    })
+
     it('should stringify objects when rendering in input', () => {
       container.innerHTML = '<input bind-value="data" />'
       const viewModel = { data: { key: 'value' } }

--- a/packages/core/src/bindings/bindValue.test.ts
+++ b/packages/core/src/bindings/bindValue.test.ts
@@ -288,5 +288,29 @@ describe('bindValue', () => {
 
       expect(input.checked).toBe(false)
     })
+
+    it('should handle invalid JSON string when current value is object', () => {
+      container.innerHTML = '<input bind-value="data" />'
+      const viewModel = { data: { key: 'value' } }
+
+      setupValueBindings(container, viewModel)
+
+      const input = container.querySelector('input')!
+      input.value = 'invalid json'
+      input.dispatchEvent(new Event('input'))
+
+      expect(viewModel.data).toBe('invalid json')
+    })
+
+    it('should stringify objects when rendering in input', () => {
+      container.innerHTML = '<input bind-value="data" />'
+      const viewModel = { data: { key: 'value' } }
+      const bindings = setupValueBindings(container, viewModel)
+
+      renderValueBindings(bindings, viewModel)
+
+      const input = container.querySelector('input')!
+      expect(input.value).toBe('[{"key":1},"value"]')
+    })
   })
 })

--- a/packages/core/src/bindings/bindValue.ts
+++ b/packages/core/src/bindings/bindValue.ts
@@ -1,3 +1,4 @@
+import { parse, stringify } from 'devalue'
 import { extractElementSnippet, filterOwnElements, findAllElements } from '../commons/helpers'
 import { getDecimalSeparator, getThousandsSeparator } from '../commons/i18n'
 import { UnsupportedElementError } from '../errors'
@@ -32,6 +33,17 @@ function setupSingleValueBinding<T extends object>(
     }
 
     const inputValue = target.value
+
+    if (typeof currentValue === 'object' && currentValue !== null) {
+      try {
+        const parsed = parse(inputValue)
+        setNestedProperty(viewModel, propertyName, parsed)
+        return
+      } catch {
+        setNestedProperty(viewModel, propertyName, inputValue)
+        return
+      }
+    }
 
     if (typeof currentValue === 'number') {
       const separator = getDecimalSeparator()
@@ -78,8 +90,14 @@ function renderSingleValueBinding<T extends object>(
     ;(input as HTMLInputElement).checked = !!value
   } else {
     const newValue = value ?? ''
-    if (input.value !== String(newValue)) {
-      input.value = String(newValue)
+    let stringValue = String(newValue)
+
+    if (typeof newValue === 'object' && newValue !== null) {
+      stringValue = stringify(newValue)
+    }
+
+    if (input.value !== stringValue) {
+      input.value = stringValue
     }
   }
 }

--- a/packages/core/src/bindings/dependencyTracker.test.ts
+++ b/packages/core/src/bindings/dependencyTracker.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from 'vitest'
 import { DependencyTracker } from './dependencyTracker'
 import type { BindingsCollection, ComponentBinding } from './types'
 
+const emptyBindings = (): BindingsCollection => ({
+  valueBindings: [],
+  contentBindings: [],
+  srcBindings: [],
+  ifBindings: [],
+  classBindings: [],
+  styleBindings: [],
+  forEachBindings: [],
+  componentBindings: [],
+})
+
 describe('DependencyTracker', () => {
   describe('registerDependency', () => {
     it('should register a dependency for a binding', () => {
@@ -14,13 +25,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding, 'users')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindings('users', bindings)
@@ -38,13 +44,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding, 'user.name')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affectedByUser = tracker.getDependentBindings('user', bindings)
@@ -72,13 +73,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding2, 'items')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding1, binding2],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindings('users', bindings)
@@ -97,13 +93,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding, 'users')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindings('users.0.name', bindings)
@@ -121,13 +112,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding, 'users.0.name')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindings('users', bindings)
@@ -150,13 +136,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding2, 'items')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding1, binding2],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindings('newUserName', bindings)
@@ -186,13 +167,10 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(classBinding, 'classes')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [valueBinding],
-        contentBindings: [],
         ifBindings: [ifBinding],
         classBindings: [classBinding],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affectedByMessage = tracker.getDependentBindings('message', bindings)
@@ -222,13 +200,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(forEachBinding, 'users')
 
       const bindings: BindingsCollection = {
-        valueBindings: [],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
+        ...emptyBindings(),
         forEachBindings: [forEachBinding],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindings('users', bindings)
@@ -247,13 +220,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding, 'user.profile.name')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affectedByUser = tracker.getDependentBindings('user', bindings)
@@ -275,13 +243,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding, 'user')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affectedByName = tracker.getDependentBindings('user.name', bindings)
@@ -307,13 +270,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(binding2, 'prueba.direccion.calle.nombre')
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [binding1, binding2],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       // Cambio en prueba.nombre → solo debe afectar binding1
@@ -363,13 +321,8 @@ describe('DependencyTracker', () => {
       tracker.markAsGetterBinding(forEachBinding)
 
       const bindings: BindingsCollection = {
-        valueBindings: [],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
+        ...emptyBindings(),
         forEachBindings: [forEachBinding],
-        componentBindings: [],
       }
 
       // Change in primitive property should trigger getter binding
@@ -396,12 +349,7 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(componentBinding, 'selectedPersonName', viewModel)
 
       const bindings: BindingsCollection = {
-        valueBindings: [],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
+        ...emptyBindings(),
         componentBindings: [componentBinding],
       }
 
@@ -428,13 +376,8 @@ describe('DependencyTracker', () => {
       tracker.registerDependency(valueBinding, 'selectedPersonName', viewModel)
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [valueBinding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
-        forEachBindings: [],
-        componentBindings: [],
       }
 
       const affected = tracker.getDependentBindingsWithGetterSupport('selectedIndex', bindings)
@@ -482,11 +425,8 @@ describe('DependencyTracker', () => {
       tracker.markAsGetterBinding(forEachBinding)
 
       const bindings: BindingsCollection = {
+        ...emptyBindings(),
         valueBindings: [valueBinding],
-        contentBindings: [],
-        ifBindings: [],
-        classBindings: [],
-        styleBindings: [],
         forEachBindings: [forEachBinding],
         componentBindings: [componentBinding],
       }

--- a/packages/core/src/bindings/setupBindings.ts
+++ b/packages/core/src/bindings/setupBindings.ts
@@ -4,6 +4,7 @@ import { renderComponentBindings, setupComponentBindings } from './bindComponent
 import { renderContentBindings, setupContentBindings } from './bindContent'
 import { renderForEachBindings, setupForEachBindings } from './bindForEach'
 import { renderIfBindings, setupIfBindings } from './bindIf'
+import { renderSrcBindings, setupSrcBindings } from './bindSrc'
 import { renderStyleBindings, setupStyleBindings } from './bindStyle'
 import { renderValueBindings, setupValueBindings } from './bindValue'
 import { DependencyTracker } from './dependencyTracker'
@@ -14,6 +15,7 @@ import type {
   ContentBinding,
   ForEachBinding,
   IfBinding,
+  SrcBinding,
   StyleBinding,
   ValueBinding,
   ViewModel,
@@ -23,6 +25,7 @@ type AnyBinding =
   | ForEachBinding
   | ValueBinding
   | ContentBinding
+  | SrcBinding
   | IfBinding
   | ClassBinding
   | StyleBinding
@@ -52,6 +55,10 @@ function registerAllBindingDependencies(
     {
       list: bindings.contentBindings,
       getPath: (binding) => (binding as ContentBinding).propertyName,
+    },
+    {
+      list: bindings.srcBindings,
+      getPath: (binding) => (binding as SrcBinding).propertyName,
     },
     {
       list: bindings.ifBindings,
@@ -105,6 +112,10 @@ function executeRenderPipeline<T extends object>(
       render: () => renderContentBindings(targetBindings.contentBindings, viewModel),
     },
     {
+      condition: () => targetBindings.srcBindings.length > 0,
+      render: () => renderSrcBindings(targetBindings.srcBindings, viewModel),
+    },
+    {
       condition: () => targetBindings.ifBindings.length > 0,
       render: () => renderIfBindings(targetBindings.ifBindings, viewModel),
     },
@@ -140,6 +151,7 @@ export function setupBindings<T extends object>(
     componentBindings: setupComponentBindings(root, viewModel),
     valueBindings: setupValueBindings(root, viewModel),
     contentBindings: setupContentBindings(root, viewModel),
+    srcBindings: setupSrcBindings(root, viewModel),
     ifBindings: setupIfBindings(root, viewModel, skipRootIf),
     classBindings: setupClassBindings(root, viewModel),
     styleBindings: setupStyleBindings(root, viewModel),

--- a/packages/core/src/bindings/setupBindings.ts
+++ b/packages/core/src/bindings/setupBindings.ts
@@ -86,6 +86,7 @@ function registerAllBindingDependencies(
 function executeRenderPipeline<T extends object>(
   targetBindings: BindingsCollection,
   viewModel: ViewModel<T>,
+  changedPath?: string,
 ): void {
   const renderActions: Array<{
     condition: () => boolean
@@ -117,7 +118,8 @@ function executeRenderPipeline<T extends object>(
     },
     {
       condition: () => targetBindings.componentBindings.length > 0,
-      render: () => renderComponentBindings(targetBindings.componentBindings, viewModel),
+      render: () =>
+        renderComponentBindings(targetBindings.componentBindings, viewModel, changedPath),
     },
   ]
 
@@ -153,7 +155,7 @@ export function setupBindings<T extends object>(
       ? tracker.getDependentBindingsWithGetterSupport(changedPath, bindings)
       : bindings
 
-    executeRenderPipeline(targetBindings, viewModel)
+    executeRenderPipeline(targetBindings, viewModel, changedPath)
   }
 
   render()

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -16,6 +16,11 @@ export type ContentBinding = {
   propertyName: string
 }
 
+export type SrcBinding = {
+  element: HTMLImageElement
+  propertyName: string
+}
+
 export type IfBinding = {
   element: HTMLElement
   propertyName: string
@@ -59,6 +64,7 @@ export type ComponentBinding = {
 export type BindingsCollection = {
   valueBindings: ValueBinding[]
   contentBindings: ContentBinding[]
+  srcBindings: SrcBinding[]
   ifBindings: IfBinding[]
   classBindings: ClassBinding[]
   styleBindings: StyleBinding[]

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -53,6 +53,7 @@ export type ForEachBinding = {
 export type ComponentBinding = {
   childViewModel: ViewModel
   mappings: Array<{ parentKey: string; childKey: string }>
+  renderChild?: (changedPath?: string) => void
 }
 
 export type BindingsCollection = {

--- a/packages/core/src/bindings/types.ts
+++ b/packages/core/src/bindings/types.ts
@@ -1,4 +1,5 @@
 export type ViewModel<T extends object = object> = T & {
+  initialize?: () => void | Promise<void>
   [key: string]: unknown
 }
 

--- a/packages/core/src/bootstrap/bootstrap.test.ts
+++ b/packages/core/src/bootstrap/bootstrap.test.ts
@@ -100,6 +100,30 @@ describe('bootstrap', () => {
     }).toThrow(ViewModelRegistrationError)
   })
 
+  it('should call initialize() if it exists in the view model', () => {
+    document.body.innerHTML = `
+      <pelela view-model="InitVM">
+        <span bind-content="message"></span>
+      </pelela>
+    `
+
+    const initSpy = vi.fn()
+    class InitViewModel {
+      message = 'Initial'
+      initialize() {
+        initSpy()
+        this.message = 'Initialized'
+      }
+    }
+
+    registerViewModel('InitVM', InitViewModel)
+    bootstrap()
+
+    expect(initSpy).toHaveBeenCalled()
+    const span = document.querySelector('span')!
+    expect(span.innerHTML).toBe('Initialized')
+  })
+
   it('should show warning if no pelela elements found', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     document.body.innerHTML = '<div>No pelela elements</div>'

--- a/packages/core/src/bootstrap/bootstrap.ts
+++ b/packages/core/src/bootstrap/bootstrap.ts
@@ -40,5 +40,9 @@ export function bootstrap(options: PelelaOptions = {}): void {
     ;(root as HTMLElement & { __pelelaViewModel: unknown }).__pelelaViewModel = reactiveInstance
     render = setupBindings(root, reactiveInstance)
     console.log(`[pelela] View model "${name}" instantiated and bound`, reactiveInstance)
+
+    if (typeof reactiveInstance.initialize === 'function') {
+      reactiveInstance.initialize()
+    }
   })
 }

--- a/packages/core/src/commons/dom.test.ts
+++ b/packages/core/src/commons/dom.test.ts
@@ -48,6 +48,11 @@ describe('dom utilities', () => {
       expect(isValidComponentAttribute('prop-data')).toBe(true)
     })
 
+    it('returns true for const- prefix', () => {
+      expect(isValidComponentAttribute('const-value')).toBe(true)
+      expect(isValidComponentAttribute('const-field-name')).toBe(true)
+    })
+
     it('returns true for "if" attribute', () => {
       expect(isValidComponentAttribute('if')).toBe(true)
     })

--- a/packages/core/src/commons/dom.ts
+++ b/packages/core/src/commons/dom.ts
@@ -25,6 +25,7 @@ export function isPelelaRootTag(tagName: string): boolean {
 
 export const LINK_PREFIX = 'link-'
 export const PROP_PREFIX = 'prop-'
+export const CONST_PREFIX = 'const-'
 
 function isValidBindingAttrForComponent(attrName: string): boolean {
   return attrName === 'if'
@@ -34,6 +35,7 @@ export function isValidComponentAttribute(attrName: string): boolean {
   return (
     attrName.startsWith(LINK_PREFIX) ||
     attrName.startsWith(PROP_PREFIX) ||
+    attrName.startsWith(CONST_PREFIX) ||
     isValidBindingAttrForComponent(attrName)
   )
 }

--- a/packages/core/src/commons/locales/en.ts
+++ b/packages/core/src/commons/locales/en.ts
@@ -52,7 +52,7 @@ const errors = {
     foreignPropertyBinding:
       'Pelela template "{{filePath}}" contains Angular-like property binding ("[property]=value"). PelelaJS does not support JS constructs in HTML. Pass static attributes and delegate logic to the ViewModel.',
     invalidComponentAttribute:
-      'Component <{{tag}}>: attribute "{{attr}}" must use "prop-" (one-way) or "link-" (two-way) prefix',
+      'Component <{{tag}}>: attribute "{{attr}}" must use "prop-" (one-way), "link-" (two-way) or "const-" prefix',
     missingParentProperty:
       'Component <{{tag}}>: parent property "{{parentKey}}" does not exist in parent view model',
     missingViewModel: 'Pelela template "{{filePath}}" must contain view-model="..." attribute',

--- a/packages/core/src/commons/locales/en.ts
+++ b/packages/core/src/commons/locales/en.ts
@@ -4,6 +4,7 @@ const errors = {
   bindings: {
     invalidSyntax:
       '[pelela] Invalid {{kind}} expression: "{{expression}}". Expected format: {{format}}',
+    srcOnlyForImg: 'bind-src can only be used on <img> elements. Found on <{{tag}}>.',
     value: {
       invalidElement:
         'bind-value can only be used on input, textarea, or select elements. Found on <{{tagName}}>. Use bind-content for display elements.\nElement: {{snippet}}',

--- a/packages/core/src/commons/locales/es.ts
+++ b/packages/core/src/commons/locales/es.ts
@@ -4,6 +4,7 @@ const errors = {
   bindings: {
     invalidSyntax:
       '[pelela] Expresión {{kind}} inválida: "{{expression}}". Formato esperado: {{format}}',
+    srcOnlyForImg: 'bind-src solo puede usarse en elementos <img>. Se encontró en <{{tag}}>.',
     value: {
       invalidElement:
         'bind-value solo puede usarse en elementos input, textarea o select. Se encontró en <{{tagName}}>. Usá bind-content para elementos de visualización.\nElemento: {{snippet}}',

--- a/packages/core/src/commons/locales/es.ts
+++ b/packages/core/src/commons/locales/es.ts
@@ -56,7 +56,7 @@ const errors = {
     foreignPropertyBinding:
       'Pelela template "{{filePath}}" contiene property binding tipo Angular ("[property]=value"). En PelelaJS no se admiten construcciones JS en HTML. Pase atributos estáticos y delegue lógica al ViewModel.',
     invalidComponentAttribute:
-      'Componente <{{tag}}>: el atributo "{{attr}}" debe usar el prefijo "prop-" (one-way) o "link-" (two-way)',
+      'Componente <{{tag}}>: el atributo "{{attr}}" debe usar el prefijo "prop-" (one-way), "link-" (two-way) o "const-"',
     missingParentProperty:
       'Componente <{{tag}}>: la propiedad padre "{{parentKey}}" no existe en el view model padre',
     missingViewModel: 'Pelela template "{{filePath}}" debe contener atributo view-model="..."',

--- a/packages/core/src/commons/locales/translationSchema.ts
+++ b/packages/core/src/commons/locales/translationSchema.ts
@@ -1,6 +1,7 @@
 type ErrorTranslations = {
   bindings: {
     invalidSyntax: string
+    srcOnlyForImg: string
     value: {
       invalidElement: string
     }

--- a/packages/core/src/errors/PropertyValidationError.ts
+++ b/packages/core/src/errors/PropertyValidationError.ts
@@ -5,6 +5,7 @@ export type BindingKind =
   | 'bind-class'
   | 'bind-value'
   | 'bind-content'
+  | 'bind-src'
   | 'bind-style'
   | 'for-each'
   | 'if'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { bootstrap } from './bootstrap/bootstrap'
 export { mountTemplate } from './bootstrap/mountTemplate'
 export {
+  CONST_PREFIX,
   isPelelaRootTag,
   isStandardHtmlTag,
   isValidComponentAttribute,

--- a/packages/core/src/reactivity/initialize.test.ts
+++ b/packages/core/src/reactivity/initialize.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { bootstrap } from '../bootstrap/bootstrap'
+import { clearRegistry, registerViewModel } from '../registry/viewModelRegistry'
+
+describe('ViewModel initialize()', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    clearRegistry()
+    // Mock global fetch
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should update DOM reactively when initialize() is async', async () => {
+    // Mock a slow API response
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ name: 'pikachu' }),
+      }),
+    )
+
+    class AsyncVM {
+      pokemon = 'loading...'
+      async initialize() {
+        const response = await fetch('https://pokeapi.co/api/v2/pokemon/25')
+        const data = await response.json()
+        this.pokemon = data.name
+      }
+    }
+
+    document.body.innerHTML = `
+      <pelela view-model="AsyncVM">
+        <h1 bind-content="pokemon"></h1>
+      </pelela>
+    `
+
+    registerViewModel('AsyncVM', AsyncVM)
+    bootstrap()
+
+    const h1 = document.querySelector('h1')!
+
+    // Initial state before promise resolves
+    expect(h1.innerHTML).toBe('loading...')
+
+    // Wait for all microtasks (promises) to settle
+    await vi.waitFor(() => {
+      if (h1.innerHTML !== 'pikachu') throw new Error('Not yet updated')
+    })
+
+    expect(h1.innerHTML).toBe('pikachu')
+  })
+})

--- a/packages/core/src/reactivity/reactiveProxy.ts
+++ b/packages/core/src/reactivity/reactiveProxy.ts
@@ -61,8 +61,10 @@ class ReactiveHandler<T extends object> implements ProxyHandler<T> {
     const oldValue = Reflect.get(targetObject, propertyKey, receiver)
 
     // Always notify for array property assignments (like .length) to catch in-place mutations
-    const isArrayProperty = Array.isArray(targetObject) && typeof propertyKey === 'string'
-    if (!isArrayProperty && oldValue === value) {
+    const isArrayMutation =
+      Array.isArray(targetObject) &&
+      (propertyKey === 'length' || (typeof propertyKey === 'string' && /^\d+$/.test(propertyKey)))
+    if (!isArrayMutation && oldValue === value) {
       return true
     }
 

--- a/packages/core/src/reactivity/reactiveProxy.ts
+++ b/packages/core/src/reactivity/reactiveProxy.ts
@@ -60,7 +60,9 @@ class ReactiveHandler<T extends object> implements ProxyHandler<T> {
   set(targetObject: T, propertyKey: string | symbol, value: unknown, receiver: unknown): boolean {
     const oldValue = Reflect.get(targetObject, propertyKey, receiver)
 
-    if (oldValue === value) {
+    // Always notify for array property assignments (like .length) to catch in-place mutations
+    const isArrayProperty = Array.isArray(targetObject) && typeof propertyKey === 'string'
+    if (!isArrayProperty && oldValue === value) {
       return true
     }
 

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -14,6 +14,7 @@ class ProductCatalog {
 class ProductDetail {
   name = 'Laptop Pro'
   price = 1299
+  imageUrl = 'laptop.png'
   isAvailable() {
     return this.price > 0
   }
@@ -26,7 +27,8 @@ class NotFoundPage {
 
 const CATALOG_TEMPLATE =
   '<pelela view-model="ProductCatalog"><h1 bind-content="count"></h1></pelela>'
-const DETAIL_TEMPLATE = '<pelela view-model="ProductDetail"><p bind-content="name"></p></pelela>'
+const DETAIL_TEMPLATE =
+  '<pelela view-model="ProductDetail"><p bind-content="name"></p><img bind-src="imageUrl" /></pelela>'
 const NOT_FOUND_TEMPLATE =
   '<pelela view-model="NotFoundPage"><p bind-content="message"></p></pelela>'
 
@@ -122,6 +124,8 @@ describe('router', () => {
 
       expect(container.querySelector('h1')).toBeNull()
       expect(container.querySelector('p')).toBeInstanceOf(HTMLParagraphElement)
+      expect(container.querySelector('img')).toBeInstanceOf(HTMLImageElement)
+      expect(container.querySelector('img')!.getAttribute('src')).toBe('laptop.png')
     })
 
     it('should update the browser URL', () => {

--- a/plans/for-each-nested-paths-and-option-value.md
+++ b/plans/for-each-nested-paths-and-option-value.md
@@ -1,0 +1,435 @@
+# Fix: for-each con paths anidados y valor de option automático
+
+## Contexto
+
+El issue #113 reporta dos problemas:
+
+**Problema 1 — No se puede definir una iteración for-each en base a una propiedad anidada**
+
+Actualmente el parser de for-each solo acepta identificadores simples (ej: `item of items`), no paths con puntos (ej: `valor of apuesta.tipoApuesta.valoresAApostar`). Esto limita la capacidad de iterar sobre propiedades anidadas del ViewModel.
+
+**Problema 2 — El option tiene un valor incorrecto**
+
+Cuando se usa `<option for-each="tipo of tipos" bind-content="tipo.descripcion">`, el option muestra la descripción correctamente pero su valor es el string de la descripción. Esto impide que el select se bindee al objeto completo, lo cual es necesario para acceder a propiedades anidadas del objeto seleccionado (ej: `tipo.valoresAApostar`).
+
+**Solución propuesta por el usuario**:
+
+- No debería hacer falta un `bind-value` explícito en el option
+- Si el for-each es `element in elements`, el option debería automáticamente tener como valor el **element** (el objeto), no la descripción que se muestra con `bind-content`
+- El `bind-content` solo define qué mostrar, pero el valor del option debería ser el objeto completo del for-each
+
+---
+
+## Plan iterativo
+
+> [!CAUTION]
+> **REGLA ESTRICTA**: Al finalizar cada checkpoint, DEBO DETENERME y esperar la confirmación explícita ("OK") del usuario antes de avanzar al siguiente. NO debo ejecutar ni editar archivos del siguiente checkpoint hasta recibir luz verde.
+
+### Checkpoint 1 — Soportar paths anidados en for-each
+
+#### [MODIFY] `packages/core/src/bindings/bindForEach.ts`
+
+**Cambio 1 — Actualizar `parseForEachExpression` para aceptar paths con puntos**
+
+```typescript
+function parseForEachExpression(
+  expression: string,
+): { itemName: string; collectionName: string } | null {
+  const identifier = IDENTIFIER_PATTERN.source.replace(/^\^|\$$/g, '')
+  // Accept both simple identifiers and nested paths (e.g., "item of items" or "valor of apuesta.tipoApuesta.valoresAApostar")
+  const match = expression.trim().match(new RegExp(`^(${identifier})\\s+of\\s+(${identifier}(\\.${identifier})*)$`))
+  if (!match) return null
+  return { itemName: match[1], collectionName: match[2] }
+}
+```
+
+**Cambio 2 — Usar `getNestedProperty` para obtener la colección**
+
+```typescript
+assertViewModelProperty(viewModel, collectionName, 'for-each', element)
+const collection = collectionName.includes('.')
+  ? getNestedProperty(viewModel, collectionName)
+  : viewModel[collectionName]
+```
+
+**Cambio 3 — Actualizar `extractExtraDependencies` para paths anidados**
+
+El `collectionName` ahora puede ser un path anidado, por lo que necesitamos extraer el primer segmento para las dependencias:
+
+```typescript
+.map((propPath) => {
+  // If collectionName is a nested path, use the first segment for dependency tracking
+  const collectionFirstSegment = collectionName.split('.')[0]
+  return propPath.startsWith(collectionFirstSegment) ? collectionFirstSegment : propPath
+})
+```
+
+#### [MODIFY] `packages/core/src/bindings/bindForEach.test.ts`
+
+Agregar tests para verificar que for-each funciona con paths anidados:
+
+```typescript
+it('should support nested paths in for-each collection', () => {
+  container.innerHTML = `
+    <div>
+      <span for-each="valor of apuesta.tipoApuesta.valoresAApostar" bind-content="valor"></span>
+    </div>
+  `
+
+  const viewModel = {
+    apuesta: {
+      tipoApuesta: {
+        valoresAApostar: [10, 20, 30],
+      },
+    },
+  }
+
+  const bindings = setupForEachBindings(container, viewModel)
+  renderForEachBindings(bindings, viewModel)
+
+  const spans = container.querySelectorAll('span')
+  expect(spans).toHaveLength(3)
+  expect(spans[0].textContent).toBe('10')
+  expect(spans[1].textContent).toBe('20')
+  expect(spans[2].textContent).toBe('30')
+})
+
+it('should react to changes in nested for-each collection', () => {
+  container.innerHTML = `
+    <div>
+      <span for-each="valor of apuesta.tipoApuesta.valoresAApostar" bind-content="valor"></span>
+    </div>
+  `
+
+  const viewModel = {
+    apuesta: {
+      tipoApuesta: {
+        valoresAApostar: [10, 20],
+      },
+    },
+  }
+
+  const bindings = setupForEachBindings(container, viewModel)
+  renderForEachBindings(bindings, viewModel)
+
+  let spans = container.querySelectorAll('span')
+  expect(spans).toHaveLength(2)
+
+  viewModel.apuesta.tipoApuesta.valoresAApostar.push(30)
+  renderForEachBindings(bindings, viewModel)
+
+  spans = container.querySelectorAll('span')
+  expect(spans).toHaveLength(3)
+})
+```
+
+**Punto de control**: los tests nuevos pasan. ✓ → pasar al Checkpoint 2.
+
+---
+
+### Checkpoint 2 — Valor automático de option basado en el elemento del for-each
+
+#### [MODIFY] `packages/core/src/bindings/bindForEach.ts`
+
+**Cambio 1 — Detectar cuando un option está dentro de un for-each y asignar automáticamente el valor del elemento**
+
+Cuando un elemento `<option>` tiene un atributo `for-each`, necesitamos asignar automáticamente su `value` al elemento del for-each (el objeto), no al contenido del `bind-content`.
+
+```typescript
+function createNewElement<T extends object>(
+  binding: ForEachBinding,
+  viewModel: ViewModel<T>,
+  item: unknown,
+  index: number,
+): void {
+  const element = binding.template.cloneNode(true) as HTMLElement
+  const itemRef = { current: item }
+  const indexRef = { current: index }
+  const extendedViewModel = createExtendedViewModel({
+    parentViewModel: viewModel,
+    itemName: binding.itemName,
+    itemRef,
+    indexName: binding.indexName,
+    indexRef,
+  })
+  const render = setupBindingsForElement(element, extendedViewModel)
+
+  // If the element is an option, automatically set its value to the item (object)
+  if (element.tagName === 'OPTION') {
+    ;(element as HTMLOptionElement).value = JSON.stringify(item)
+  }
+
+  const lastElement =
+    binding.renderedElements[binding.renderedElements.length - 1]?.element || binding.placeholder
+  binding.renderedElements.push({
+    element,
+    viewModel: extendedViewModel,
+    itemRef,
+    indexRef,
+    render,
+  })
+  if (lastElement.parentNode) {
+    lastElement.parentNode.insertBefore(element, lastElement.nextSibling)
+    render()
+  }
+}
+```
+
+**Cambio 2 — Actualizar `updateExistingElements` para mantener el valor del option**
+
+```typescript
+function updateExistingElements(binding: ForEachBinding, collection: unknown[]): void {
+  binding.renderedElements.forEach((rendered, index) => {
+    rendered.itemRef.current = collection[index]
+    rendered.indexRef.current = index
+
+    // Update option value if the element is an option
+    if (rendered.element.tagName === 'OPTION') {
+      ;(rendered.element as HTMLOptionElement).value = JSON.stringify(collection[index])
+    }
+
+    rendered.render()
+  })
+}
+```
+
+#### [MODIFY] `packages/core/src/bindings/bindValue.ts`
+
+**Cambio 1 — Parsear el valor del select como JSON cuando es un objeto**
+
+Cuando el valor del select es un string JSON, intentar parsearlo para obtener el objeto original:
+
+```typescript
+function renderSingleValueBinding<T extends object>(
+  binding: ValueBinding,
+  viewModel: ViewModel<T>,
+): void {
+  const value = getNestedProperty(viewModel, binding.propertyName)
+
+  const input = binding.element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+  const isCheckbox = input instanceof HTMLInputElement && input.type === 'checkbox'
+
+  if (isCheckbox) {
+    ;(input as HTMLInputElement).checked = !!value
+  } else {
+    const newValue = value ?? ''
+    let stringValue = String(newValue)
+
+    // If the value is an object, stringify it for comparison
+    if (typeof newValue === 'object' && newValue !== null) {
+      stringValue = JSON.stringify(newValue)
+    }
+
+    if (input.value !== stringValue) {
+      input.value = stringValue
+    }
+  }
+}
+```
+
+**Cambio 2 — Parsear el valor del input del usuario como JSON cuando corresponde**
+
+```typescript
+element.addEventListener(isCheckbox ? 'change' : 'input', (event) => {
+  const target = event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+  const currentValue = getNestedProperty(viewModel, propertyName)
+
+  if (isCheckbox) {
+    setNestedProperty(viewModel, propertyName, (target as HTMLInputElement).checked)
+    return
+  }
+
+  const inputValue = target.value
+
+  // Try to parse as JSON if the current value is an object
+  if (typeof currentValue === 'object' && currentValue !== null) {
+    try {
+      const parsed = JSON.parse(inputValue)
+      setNestedProperty(viewModel, propertyName, parsed)
+      return
+    } catch {
+      // If parsing fails, fall through to string handling
+    }
+  }
+
+  if (typeof currentValue === 'number') {
+    const separator = getDecimalSeparator()
+    const thousandsSeparator = getThousandsSeparator()
+
+    const normalizedValue = inputValue
+      .replace(/\s/g, '')
+      .split(thousandsSeparator)
+      .join('')
+      .replace(separator, '.')
+
+    const numeric = Number(normalizedValue)
+    setNestedProperty(viewModel, propertyName, Number.isNaN(numeric) ? 0 : numeric)
+  } else {
+    setNestedProperty(viewModel, propertyName, inputValue)
+  }
+})
+```
+
+#### [MODIFY] `packages/core/src/bindings/bindForEach.test.ts`
+
+Agregar tests para verificar que el option tiene el valor del objeto:
+
+```typescript
+it('should set option value to the for-each item object', () => {
+  container.innerHTML = `
+    <select>
+      <option for-each="tipo of tipos" bind-content="tipo.descripcion"></option>
+    </select>
+  `
+
+  const viewModel = {
+    tipos: [
+      { descripcion: 'Tipo A', value: 1 },
+      { descripcion: 'Tipo B', value: 2 },
+    ],
+  }
+
+  const bindings = setupForEachBindings(container, viewModel)
+  renderForEachBindings(bindings, viewModel)
+
+  const options = container.querySelectorAll('option')
+  expect(options).toHaveLength(2)
+  expect(options[0].textContent).toBe('Tipo A')
+  expect(options[0].value).toBe(JSON.stringify(viewModel.tipos[0]))
+  expect(options[1].textContent).toBe('Tipo B')
+  expect(options[1].value).toBe(JSON.stringify(viewModel.tipos[1]))
+})
+
+it('should work with select bind-value using object values', () => {
+  container.innerHTML = `
+    <select bind-value="selectedTipo">
+      <option for-each="tipo of tipos" bind-content="tipo.descripcion"></option>
+    </select>
+  `
+
+  const viewModel = {
+    tipos: [
+      { descripcion: 'Tipo A', value: 1 },
+      { descripcion: 'Tipo B', value: 2 },
+    ],
+    selectedTipo: null as { descripcion: string; value: number } | null,
+  }
+
+  const valueBindings = setupValueBindings(container, viewModel)
+  const forEachBindings = setupForEachBindings(container, viewModel)
+  renderForEachBindings(forEachBindings, viewModel)
+  renderValueBindings(valueBindings, viewModel)
+
+  const select = container.querySelector('select') as HTMLSelectElement
+  expect(select.value).toBe('') // No selection initially
+
+  viewModel.selectedTipo = viewModel.tipos[0]
+  renderValueBindings(valueBindings, viewModel)
+
+  expect(select.value).toBe(JSON.stringify(viewModel.tipos[0]))
+})
+```
+
+**Punto de control**: los tests nuevos pasan. ✓ → pasar al Checkpoint 3.
+
+---
+
+### Checkpoint 3 — Ejemplo en examples/for-each
+
+#### [MODIFY] `examples/for-each/src/app.pelela`
+
+Agregar un ejemplo al final que demuestre el uso de paths anidados y objetos en select:
+
+```html
+  <hr/>
+
+  <h2>8) Select con objetos y paths anidados</h2>
+
+  <p>Tipo de apuesta:</p>
+  <select bind-value="apuesta.tipoApuesta">
+    <option for-each="tipo of tiposApuesta" bind-content="tipo.descripcion"></option>
+  </select>
+
+  <p>Valor seleccionado: <span bind-content="apuesta.tipoApuesta.descripcion"></span></p>
+
+  <p>Valores a apostar:</p>
+  <select bind-value="apuesta.valorApostado">
+    <option for-each="valor of apuesta.tipoApuesta.valoresAApostar" bind-content="valor"></option>
+  </select>
+
+  <p>Valor seleccionado: <span bind-content="apuesta.valorApostado"></span></p>
+```
+
+#### [MODIFY] `examples/for-each/src/app.ts`
+
+Agregar los datos para el nuevo ejemplo:
+
+```typescript
+interface TipoApuesta {
+  descripcion: string
+  valoresAApostar: number[]
+}
+
+export class App {
+  // ... existing properties ...
+
+  tiposApuesta: TipoApuesta[] = [
+    { descripcion: 'Ganador', valoresAApostar: [10, 20, 50] },
+    { descripcion: 'Segundo Puesto', valoresAApostar: [5, 10, 25] },
+    { descripcion: 'Tercero', valoresAApostar: [2, 5, 10] },
+  ]
+
+  apuesta = {
+    tipoApuesta: null as TipoApuesta | null,
+    valorApostado: null as number | null,
+  }
+
+  // ... existing methods ...
+}
+```
+
+**Punto de control**: levantar el ejemplo y verificar que:
+- El primer select muestra las descripciones de los tipos de apuesta
+- Al seleccionar un tipo, el segundo select se actualiza con los valores correspondientes
+- La reactividad funciona correctamente al cambiar el tipo de apuesta
+✓ → pasar al Checkpoint 4.
+
+---
+
+### Checkpoint 4 — Verificación integral
+
+1. **Tests existentes**: `pnpm test --run` sin regresiones en `bindForEach.test.ts`, `bindValue.test.ts`.
+2. **Ejemplo actualizado**: levantar `examples/for-each` y verificar que el nuevo ejemplo funciona correctamente.
+3. **Ejemplo existente**: levantar `examples/components` y verificar que no hay regresiones.
+
+---
+
+## Archivos impactados
+
+### `packages/core/src/bindings/`
+- **[MODIFY]** `bindForEach.ts` — soportar paths anidados en for-each y asignar valor automático a options
+- **[MODIFY]** `bindValue.ts` — parsear valores JSON en select
+- **[MODIFY]** `bindForEach.test.ts` — tests para paths anidados y valor de option
+- **[MODIFY]** `bindValue.test.ts` — tests para select con objetos
+
+### `examples/for-each/`
+- **[MODIFY]** `src/app.pelela` — agregar ejemplo 8 con select y paths anidados
+- **[MODIFY]** `src/app.ts` — agregar datos para el nuevo ejemplo
+
+---
+
+## Verification Plan
+
+### Automated Tests
+```bash
+# Pedir al usuario ejecutar desde la raíz del monorepo
+pnpm run test --run
+# O específicamente
+pnpm --filter @pelelajs/core test -- bindForEach
+pnpm --filter @pelelajs/core test -- bindValue
+```
+
+### Manual Verification
+- Levantar `examples/for-each` y verificar comportamiento en browser
+- Verificar que el example 8 funciona correctamente con paths anidados y objetos en select
+- Levantar `examples/components` y verificar que no hay regresiones

--- a/plans/issue-112-rename-validation.md
+++ b/plans/issue-112-rename-validation.md
@@ -1,0 +1,45 @@
+# Plan para resolver Issue #112: Mejoras en el comando Rename del CLI
+
+Este plan detalla los pasos para mejorar la validación y el comportamiento del comando `rename` en el CLI de Pelela, asegurando que se sigan las convenciones de nomenclatura y se manejen correctamente las dependencias como `routes.ts`.
+
+## 1. Validación de Nombres de Componente
+
+Actualmente, el comando `rename` valida que el nuevo nombre siga el formato CamelCase, pero no lo hace estrictamente para el nombre antiguo.
+
+- **Acción**: Actualizar `renameCommand` en `tools/pelela-cli/src/commands/rename.ts` para validar que tanto `oldComponentName` como `newComponentName` cumplan con la expresión regular `/^[A-Z][a-zA-Z0-9]*$/` (en su parte final/basename).
+- **Justificación**: Los componentes en Pelela siempre deben empezar con mayúscula y seguir CamelCase.
+
+## 2. Claridad en la Interfaz del CLI
+
+Mejorar la definición del comando para que los parámetros sean más descriptivos.
+
+- **Acción**: En `tools/pelela-cli/src/index.ts`, cambiar la definición del comando:
+  ```typescript
+  program
+    .command('rename <oldComponentName> <newComponentName>')
+  ```
+- **Nota**: Asegurar que los mensajes de ayuda y descripciones reflejen esta nomenclatura.
+
+## 3. Pruebas de Validación de Nomenclatura
+
+Garantizar que el CLI falle si no se respeta el CamelCase.
+
+- **Acción**: Agregar casos de prueba en `tools/pelela-cli/test/commands/rename.test.ts` que:
+  - Intenten renombrar un componente usando un nombre antiguo en minúsculas.
+  - Intenten asignar un nuevo nombre en minúsculas.
+  - Verifiquen que se lance el error esperado (`commands.rename.error.nameInvalid`).
+
+## 4. Manejo de `routes.ts`
+
+Verificar que las referencias en el archivo de rutas se actualicen correctamente.
+
+- **Acción**: El mecanismo actual `updateImports` ya recorre todos los archivos `.ts` y `.js`. Debemos verificar específicamente (o agregar un test) que si existe un archivo `routes.ts`, su contenido se actualice con el nuevo nombre del componente y su nueva ruta de importación.
+- **Detalle**: Si el archivo `routes.ts` no se encuentra o no contiene el import, el proceso debe continuar sin fallar (comportamiento actual de `replaceComponentUsage`).
+
+## 5. Resiliencia en la Actualización de Imports
+
+- **Acción**: Asegurar que si la lógica de `updateImports` no puede resolver un renombre de import específico (por ejemplo, en `routes.ts` debido a un formato inesperado), el comando no aborte la operación completa de renombrado de archivos, sino que informe o simplemente continúe de forma segura.
+
+---
+**Prioridad**: Alta
+**Estado**: Pendiente de implementación

--- a/plans/issue-119-new-command-component-flag.md
+++ b/plans/issue-119-new-command-component-flag.md
@@ -90,9 +90,9 @@ createPelelaFile(componentName, targetDir, rootTag)
 
 - **Actualizar** los tests existentes que chequeaban `<div>` como parte del contenido del `.pelela` (ya no existirá).
 - **Agregar** test: sin `--component`, el template usa `<pelela>`.
-- **Agregar** test: con `component: true`, el template usa `<component>`.
+- **Agregar** test: con `--component`, el template usa `<component>`.
 - **Agregar** test: sin `--component`, NO se agrega el componente a routes.ts.
-- **Agregar** test: con `component: true`, NO se agrega el componente a routes.ts.
+- **Agregar** test: con `--component`, NO se agrega el componente a routes.ts.
 
 ---
 
@@ -109,6 +109,7 @@ createPelelaFile(componentName, targetDir, rootTag)
 
 ## Verificación
 
+Es manual, NO LO PODES EJECUTAR SI SOS UNA IA. Pedís autorización al usuario.
 ```bash
 pnpm --filter pelela-cli test
 pnpm run biome:check

--- a/plans/issue-121-add-bind-src.md
+++ b/plans/issue-121-add-bind-src.md
@@ -1,0 +1,63 @@
+# Plan: Agregar bind-src para tags img (Issue #121)
+
+## Contexto
+Se requiere implementar una nueva directiva de binding `bind-src` específicamente para elementos `<img>`. Esto permitirá actualizar dinámicamente el atributo `src` de las imágenes desde el ViewModel, algo fundamental para ejemplos como el de países (mostrar banderas).
+
+## Requerimientos
+1. Validar que `bind-src` solo se use en tags `<img>`.
+2. Integrar la directiva en el motor de reactividad de PelelaJS.
+3. Agregar soporte de resaltado de sintaxis en la extensión de VSCode.
+4. Incluir un ejemplo de uso en el sistema de routing.
+5. Garantizar cobertura de tests unitarios.
+
+## Cambios Propuestos
+
+### 1. Core: Estructura y Tipado
+- **Archivo:** `packages/core/src/bindings/types.ts`
+  - Definir `SrcBinding` (usando `HTMLImageElement`).
+  - Agregar `srcBindings: SrcBinding[]` a `BindingsCollection`.
+- **Archivo:** `packages/core/src/errors/PropertyValidationError.ts`
+  - Agregar `'bind-src'` al tipo `BindingKind`.
+
+### 2. Core: Lógica de Binding
+- **Nuevo Archivo:** `packages/core/src/bindings/bindSrc.ts`
+  - Implementar `setupSrcBindings`:
+    - Buscar elementos con `[bind-src]`.
+    - Validar que el elemento sea `HTMLImageElement`. Si no, lanzar error `srcOnlyForImg`.
+    - Usar `assertViewModelProperty` para validar la propiedad en el ViewModel.
+  - Implementar `renderSrcBindings`:
+    - Actualizar `element.src` solo si el valor del ViewModel cambió.
+
+### 3. Core: Integración
+- **Archivo:** `packages/core/src/bindings/setupBindings.ts`
+  - Importar `setupSrcBindings` y `renderSrcBindings`.
+  - Registrar en `setupBindings` para la inicialización.
+  - Registrar la dependencia en `registerAllBindingDependencies`.
+  - Agregar a `executeRenderPipeline`.
+
+### 4. Internacionalización (i18n)
+- **Archivo:** `packages/core/src/commons/locales/translationSchema.ts`
+  - Agregar `srcOnlyForImg` al esquema.
+- **Archivos:** `packages/core/src/commons/locales/es.ts` y `en.ts`
+  - Agregar las traducciones correspondientes para el error de validación de tag.
+
+### 5. Herramientas: Pelela VSCode
+- **Archivo:** `tools/pelela-vscode/syntaxes/pelela.tmLanguage.json`
+  - Agregar `bind-src` a los patrones de atributos para el resaltado de sintaxis.
+
+### 6. Ejemplo en Routing
+- **Archivo:** `packages/core/src/router/router.test.ts` (u otro test de integración de routing)
+  - Modificar un componente de ejemplo para incluir una imagen con `bind-src` (ej: una bandera en una lista de países).
+
+### 7. Verificación (Testing)
+- **Nuevo Archivo:** `packages/core/src/bindings/bindSrc.test.ts`
+  - Test: Actualización reactiva del `src`.
+  - Test: Error al usar en tags no permitidos.
+  - Test: Manejo de valores nulos o indefinidos.
+
+## Verificación Final
+Ejecutar:
+```bash
+pnpm run test packages/core/src/bindings/bindSrc.test.ts
+pnpm run biome:check
+```

--- a/plans/issue-122-view-model-initialize.md
+++ b/plans/issue-122-view-model-initialize.md
@@ -1,0 +1,49 @@
+# Plan: Agregar mecanismo de `initialize()` para el View Model (Issue #122)
+
+## Contexto
+Actualmente, los ViewModels solo tienen el `constructor` para inicializar estado. Sin embargo, en el `constructor`, `this` apunta a la instancia cruda, no al Proxy reactivo (que se crea *después* de la instanciación). Esto impide realizar llamadas asincrónicas (ej: `fetch`) que actualicen la UI automáticamente al completarse, ya que las asignaciones a `this` dentro de una promesa no son interceptadas por el Proxy.
+
+Se propone agregar un método opcional `initialize()` que el framework invocará automáticamente **después** de crear el Proxy reactivo, permitiendo inicializaciones asincrónicas reactivas.
+
+## Cambios Propuestos
+
+### 1. Core: Definición de Interfaz
+- **Archivo:** `packages/core/src/types.ts`
+  - Agregar el método opcional `initialize?: () => void | Promise<void>` a la definición de lo que puede ser un ViewModel.
+
+### 2. Core: Invocación en Bootstrap (Root components)
+- **Archivo:** `packages/core/src/bootstrap/bootstrap.ts`
+  - Localizar el punto donde se crea `reactiveInstance`.
+  - Después de asignar `render = setupBindings(...)`, verificar si `reactiveInstance` tiene el método `initialize`.
+  - Si existe, invocarlo: `reactiveInstance.initialize?.()`.
+
+### 3. Core: Invocación en BindComponent (Child components)
+- **Archivo:** `packages/core/src/bindings/bindComponent.ts`
+  - Localizar el punto en `setupComponentBindings` donde se crea el `reactiveInstance` del componente hijo.
+  - Después de completar el setup y asignar `renderChild`, verificar e invocar `reactiveInstance.initialize?.()`.
+
+### 4. Ejemplo de Uso y Verificación Manual (PokeAPI)
+- **Archivo:** `examples/routing/src/detail.ts`
+  - Agregar propiedad `favoritePokemonName: string`.
+  - Implementar `async initialize()`:
+    - Realizar un `fetch` a `https://pokeapi.co/api/v2/pokemon/${this.id}/`.
+    - Al obtener la respuesta, actualizar `this.favoritePokemonName = data.name`.
+- **Archivo:** `examples/routing/src/detail.pelela`
+  - Mostrar el nombre del pokemon favorito: `<p>Pokemon favorito: <strong bind-content="favoritePokemonName">Cargando...</strong></p>`.
+  - Esto validará que la actualización asincrónica dentro de `initialize()` dispara el re-renderizado correctamente a través del Proxy.
+
+### 5. Verificación Automática (Tests)
+- **Archivo:** `packages/core/src/bootstrap/bootstrap.test.ts`
+  - Agregar test: Verificar que `initialize()` es llamado al bootstreapear.
+- **Archivo:** `packages/core/src/bindings/bindComponent.test.ts`
+  - Agregar test: Verificar que `initialize()` es llamado en componentes hijos.
+- **Archivo:** `packages/core/src/reactivity/initialize.test.ts` (Nuevo)
+  - Test: Verificar que las actualizaciones dentro de un `initialize()` asincrónico disparan re-renders.
+
+---
+
+## Próximos Pasos (Pendiente OK)
+1. **Paso 1:** Modificar `packages/core/src/types.ts` y `bootstrap.ts`.
+2. **Paso 2:** Modificar `packages/core/src/bindings/bindComponent.ts`.
+3. **Paso 3:** Actualizar ejemplo en `examples/routing`.
+4. **Paso 4:** Agregar y ejecutar tests.

--- a/plans/navigation-child-component.md
+++ b/plans/navigation-child-component.md
@@ -1,0 +1,92 @@
+# Plan: Navegación a Componentes Hijos desde Templates `.pelela`
+
+Este plan describe los cambios necesarios para permitir la navegación ("Go to Definition") desde etiquetas de componentes hijos (custom components) en archivos de template `.pelela` hacia su correspondiente archivo `.pelela` que los define.
+
+---
+
+## Contexto
+
+Para el plugin `pelela-vscode`, los estudiantes y desarrolladores deben poder navegar a un componente hijo haciendo click o presionando F12 ("Go to Definition") en la etiqueta del componente dentro del template HTML (por ejemplo, en `<person-row>` o `<counter>`).
+
+Actualmente, `definitionProvider.ts` resuelve definiciones de:
+1. `view-model="..."` (Clase TS asociada)
+2. `bind-*="..."` (Propiedades/Getters en la clase TS)
+3. `click="..."` (Métodos en la clase TS)
+
+Pero no soporta la navegación al archivo del componente hijo en sí mismo (ej. de `<person-row>` a `person-row.pelela`).
+
+---
+
+## Decisiones de diseño
+
+- **Detección de etiqueta**: Identificaremos si la posición del cursor se encuentra sobre el nombre de una etiqueta (abertura o cierre) usando una expresión regular ágil que valide `<\/?([a-zA-Z0-9-]+)`.
+- **Filtro de etiquetas estándar HTML**: Para evitar búsquedas y accesos a disco innecesarios, reutilizaremos las funciones `isStandardHtmlTag` e `isPelelaRootTag` provistas por el paquete `@pelelajs/core` (`pelelajs`). Para no introducir overhead de bundle (evitando importar el runtime completo de la UI que además usa APIs de browser/DOM incompatibles con VS Code), usaremos un alias de ruta TypeScript (`pelelajs/dom`) apuntando directamente a `packages/core/src/commons/dom.ts`.
+- **Resolución del archivo del componente**:
+  1. Primero buscaremos el archivo de manera síncrona en el mismo directorio del documento actual (`tagName.pelela`).
+  2. Si no se encuentra, realizaremos una búsqueda asíncrona en todo el workspace usando `vscode.workspace.findFiles('**/tagName.pelela')`.
+- **Compatibilidad con Tests**: Actualizaremos el stub `test/vscode-stub.ts` para mockear `vscode.workspace.findFiles` de manera que retorne una promesa vacía por defecto, permitiendo que la suite de tests corra sin romperse.
+
+---
+
+## Plan iterativo
+
+> [!CAUTION]
+> **REGLA ESTRICTA**: Al finalizar cada checkpoint, DEBO DETENERME y reportar el progreso al usuario. NO debo realizar modificaciones sin la aprobación explícita.
+
+### Checkpoint 1 — Configuración del alias `pelelajs/dom` y Stub de `findFiles`
+
+#### [MODIFY] [tsconfig.base.json](file:///Users/fernando/workspace/algo3/pelelajs/tsconfig.base.json)
+
+Añadir el alias `"pelelajs/dom": ["./packages/core/src/commons/dom.ts"]` en los `paths` de TypeScript para que la extensión de VS Code pueda importar sólo ese archivo sin dependencias externas.
+
+#### [MODIFY] [vscode-stub.ts](file:///Users/fernando/workspace/algo3/pelelajs/tools/pelela-vscode/test/vscode-stub.ts)
+
+Añadir `findFiles` al mock del objeto `workspace` para que no lance errores de tipo "undefined" al correr la suite de tests.
+
+```typescript
+  workspace: {
+    onDidOpenTextDocument: () => ({ dispose: () => {} }),
+    findFiles: (glob: string) => Promise.resolve([]),
+  },
+```
+
+### Checkpoint 2 — Implementación de la detección de tags y búsqueda de archivos
+
+#### [MODIFY] [definitionProvider.ts](file:///Users/fernando/workspace/algo3/pelelajs/tools/pelela-vscode/src/providers/definitionProvider.ts)
+
+1. Importar `node:path` y `node:fs`.
+2. Importar `isStandardHtmlTag` e `isPelelaRootTag` desde `'pelelajs/dom'`.
+3. Implementar `checkComponentTagDefinition(document, position, lineText)`.
+4. Integrar `checkComponentTagDefinition` en `provideDefinition` como último fallback tras las validaciones actuales.
+
+### Checkpoint 3 — Tests Unitarios para el Definition Provider
+
+#### [NEW] [definitionProvider.test.ts](file:///Users/fernando/workspace/algo3/pelelajs/tools/pelela-vscode/test/providers/definitionProvider.test.ts)
+
+Crear tests unitarios usando Mocha que validen:
+1. No se resuelve navegación para tags HTML estándar (ej: `div`, `p`, `pelela`).
+2. Se resuelve correctamente la navegación para un componente local en la misma carpeta (mockeando fs.existsSync o usando archivos reales en fixtures).
+3. Se resuelve correctamente la navegación para un componente mediante `findFiles` del workspace (mockeando `vscode.workspace.findFiles`).
+4. Funciona tanto al posicionar el cursor sobre el tag de apertura `<counter>` como el de cierre `</counter>`.
+
+---
+
+## Archivos impactados
+
+### `tools/pelela-vscode/`
+- **[MODIFY]** `test/vscode-stub.ts`
+- **[MODIFY]** `src/providers/definitionProvider.ts`
+- **[NEW]** `test/providers/definitionProvider.test.ts`
+
+---
+
+## Plan de Verificación
+
+### Pruebas Automatizadas
+- Solicitar al usuario correr la suite de tests de la extensión VS Code:
+  ```bash
+  pnpm --filter pelela-vscode test
+  ```
+
+### Pruebas Manuales
+- Una vez verificado por tests, la extensión empaquetada o cargada en desarrollo podrá ser usada en el proyecto de ejemplo para navegar presionando `cmd+click` o `F12` en `<person-row>` o `<counter>` dentro de `home.pelela`.

--- a/plans/nested-prop-reactivity.md
+++ b/plans/nested-prop-reactivity.md
@@ -1,0 +1,259 @@
+# Fix: reactividad de `prop-*` con propiedades anidadas
+
+## Contexto
+
+Cuando un componente padre pasa una propiedad anidada a un hijo usando la sintaxis `prop-errors="apuesta.errors"`, la reactividad no se dispara al mutar el array `errors` en el padre (por ejemplo, con `.push()` o `.length = 0`).
+
+Hay **dos bugs independientes** que se combinan:
+
+**Bug A — Setup no resuelve paths con punto**  
+En `bindComponent.ts` L122:
+```typescript
+instance[childKey] = (parentViewModel as Record<string, unknown>)[parentKey]
+```
+`parentKey` es `"apuesta.errors"`, pero el bracket-access no resuelve paths con `.` → devuelve `undefined`. El helper `getNestedProperty` de `nestedProperties.ts` ya existe para esto y no se usa aquí.
+
+**Bug B — `renderComponentBindings` no propaga cambios en colecciones mutadas**  
+En `bindComponent.ts` L183:
+```typescript
+if (parentValue !== childValue) {  // ← falla para arrays mutados
+  childViewModel[childKey] = parentValue
+}
+```
+Cuando el array `errors` es mutado in-place (`.push`, `.length = 0`), la referencia es la misma → `parentValue === childValue` → no hay update → el hijo nunca se re-renderiza.
+
+---
+
+## Decisiones de diseño
+
+- **Validación de path**: se valida que **cada segmento intermedio** del path exista en el padre (ej. para `"apuesta.errors"` se verifica que `apuesta` exista, y que `apuesta.errors` también exista). Se soportan **N niveles de anidamiento** (`"a.b.c.d"`, etc.).
+- **`link-*` con paths anidados**: se resuelve en el mismo PR, usando `setNestedProperty` para la propagación inversa hijo → padre.
+
+---
+
+## Plan iterativo
+
+> [!CAUTION]
+> **REGLA ESTRICTA**: Al finalizar cada checkpoint, DEBO DETENERME y esperar la confirmación explícita ("OK") del usuario antes de avanzar al siguiente. NO debo ejecutar ni editar archivos del siguiente checkpoint hasta recibir luz verde.
+
+### Checkpoint 1 — Ejemplo mínimo que reproduce el bug
+
+#### [NEW] `examples/nested-prop-component/`
+
+Estructura espejada de `examples/components/`:
+
+| Archivo | Descripción |
+|---|---|
+| `index.html` | HTML raíz con `<div id="app">` |
+| `main.ts` | Bootstrap con `router.start` |
+| `vite.config.ts` | `pelelajsPlugin()` |
+| `package.json` | `pelelajs: workspace:*` |
+| `.npmrc` | `shamefully-hoist=true` |
+| `routes.ts` | Ruta `/` → `Bet` |
+| `src/bet.pelela` | Template del padre: input + botón Bet + `<error-list prop-errors="bet.errors">` |
+| `src/bet.ts` | VM padre: `bet = new BetModel()`, método `place()` que valida |
+| `src/betModel.ts` | Clase con `errors: string[]`, `amount: string`, `validate()` |
+| `src/error-list.pelela` | Template del hijo: `for-each` sobre `errors` |
+| `src/error-list.ts` | VM hijo: `errors: string[] = []` |
+
+**Comportamiento esperado al correr `pnpm dev`**: al dejar el input vacío y hacer click en "Bet", el componente `error-list` debería mostrar el error; sin el fix, no lo muestra.
+
+**Punto de control**: levantar el ejemplo y confirmar que el bug es visible en el browser. ✓ → pasar al Checkpoint 2.
+
+---
+
+### Checkpoint 2 — Tests en rojo (TDD)
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.test.ts`
+
+Agregar dos bloques de tests **que deben fallar** antes del fix:
+
+**Test A — Setup con path anidado**
+```
+it('should initialize child component with a nested parent property path (prop-errors="bet.errors")')
+```
+- Crea un padre con `{ bet: { errors: ['error1'] } }`
+- Define un hijo que recibe `prop-errors="bet.errors"`
+- Verifica que el hijo tenga `errors = ['error1']` tras el setup
+
+**Test B — Re-render del hijo al mutar array pasado como prop anidada**
+```
+it('should re-render child component when nested array prop is mutated via push()')
+it('should re-render child component when nested array prop is cleared via length = 0')
+```
+- Arranca con `errors = []`
+- Llama a `bet.errors.push('Debe ingresar monto')` en el padre (a través del proxy reactivo)
+- Verifica que el componente hijo actualizó su contenido
+
+**Punto de control**: `pnpm test` muestra estos tests en rojo. ✓ → pasar al Checkpoint 3.
+
+---
+
+### Checkpoint 3 — Fix A: soporte de paths con punto en el setup
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.ts`
+
+**Cambio 1 — Lectura inicial con `getNestedProperty`**
+
+```diff
+- instance[childKey] = (parentViewModel as Record<string, unknown>)[parentKey]
++ instance[childKey] = parentKey.includes('.')
++   ? getNestedProperty(parentViewModel, parentKey)
++   : (parentViewModel as Record<string, unknown>)[parentKey]
+```
+
+**Cambio 2 — Validación de propiedad padre para N niveles**
+
+Se valida que cada segmento previo al último exista en el objeto padre. Se usa `getNestedProperty` para recorrer el path y verificar que ningún segmento intermedio sea `undefined` o `null`:
+
+```diff
+- if (!parentKey.includes('.') && !hasProperty(parentViewModel, parentKey)) {
+-   throw new Error(...)
+- }
++ // Valida todos los segmentos intermedios del path (soporta a.b.c.d)
++ const pathSegments = parentKey.split('.')
++ let current: unknown = parentViewModel
++ for (const segment of pathSegments) {
++   if (!isObject(current) || !hasProperty(current as object, segment)) {
++     throw new Error(t('errors.compiler.missingParentProperty', { tag, parentKey }))
++   }
++   current = (current as Record<string, unknown>)[segment]
++ }
+```
+
+**Cambio 3 — Propagación inversa en `link-` con `setNestedProperty` (N niveles)**
+
+En el handler de `onChange` del `reactiveInstance`, la asignación de vuelta al padre:
+```diff
+- (parentViewModel as Record<string, unknown>)[linkBinding.parentKey] = reactiveInstance[changedPath]
++ if (linkBinding.parentKey.includes('.')) {
++   setNestedProperty(parentViewModel, linkBinding.parentKey, reactiveInstance[changedPath])
++ } else {
++   (parentViewModel as Record<string, unknown>)[linkBinding.parentKey] = reactiveInstance[changedPath]
++ }
+```
+```
+
+**Punto de control**: el Test A pasa, el Test B sigue en rojo. `pnpm test` confirma. ✓ → pasar al Checkpoint 4.
+
+---
+
+### Checkpoint 4 — Fix B: propagación correcta de arrays/objetos mutados
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.ts` — `renderComponentBindings`
+
+El problema: para colecciones (arrays/objetos) pasadas como prop, la referencia es la misma antes y después de la mutación. La comparación `!==` ignora el cambio.
+
+**Estrategia**: si el valor padre es un array u objeto y la referencia ya es la misma en el hijo, forzar igualmente la notificación al child para que re-renderice sus bindings internos.
+
+```diff
+  if (parentValue !== childValue) {
+    (binding.childViewModel as Record<string, unknown>)[childKey] = parentValue
++   // Force re-render of child when value changes
++   binding.renderChild?.(childKey)
++ } else if (isObject(parentValue)) {
++   // Misma referencia pero el objeto/array pudo haber sido mutado:
++   // forzar re-render del hijo notificando con el childKey como changedPath
++   binding.renderChild?.(childKey)
+  }
+```
+
+Para que esto funcione, `ComponentBinding` necesita exponer la función `renderChild` del hijo. Actualmente ese cierre es local a `setupComponentBindings`. Hay que almacenarlo en el binding:
+
+#### [MODIFY] `packages/core/src/bindings/types.ts`
+
+```typescript
+interface ComponentBinding {
+  childViewModel: ViewModel<object>
+  mappings: Array<{ parentKey: string; childKey: string }>
+  renderChild: (changedPath?: string) => void   // ← nuevo campo
+}
+```
+
+Y guardar la referencia al crear el binding en `setupComponentBindings`:
+```diff
+  bindings.push({
+    childViewModel: reactiveInstance,
+    mappings: allMappings,
++   renderChild,
+  })
+```
+
+#### [MODIFY] `packages/core/src/reactivity/reactiveProxy.ts` — `set` handler
+
+Para detectar mutaciones de propiedades de arrays (como `.length = 0`), siempre notificar cambios cuando se asignan propiedades de arrays, incluso si el valor es el mismo:
+
+```diff
+  set(targetObject: T, propertyKey: string | symbol, value: unknown, receiver: unknown): boolean {
+    const oldValue = Reflect.get(targetObject, propertyKey, receiver)
+
++   // Always notify for array property assignments (like .length) to catch in-place mutations
++   const isArrayProperty = Array.isArray(targetObject) && typeof propertyKey === 'string'
++   if (!isArrayProperty && oldValue === value) {
++     return true
++   }
+
+    const result = Reflect.set(targetObject, propertyKey, value, receiver)
+
+    if (result) {
+      this.notifyChange(propertyKey)
+    }
+
+    return result
+  }
+```
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.test.ts`
+
+Agregar test para verificar que el DOM del hijo se re-renderiza cuando se muta el array anidado:
+
+```typescript
+it('should re-render child DOM when nested array prop is mutated via push()', () => {
+  // ... test setup ...
+  parentVM.bet.errors.push('Error 1')
+  const updatedListItems = childEl.querySelectorAll('li')
+  expect(updatedListItems.length).toBe(1)
+  expect(updatedListItems[0].textContent).toBe('Error 1')
+})
+```
+
+**Punto de control**: todos los tests nuevos pasan. `pnpm test --run` verde. ✓ → pasar al Checkpoint 5.
+
+---
+
+### Checkpoint 5 — Verificación integral
+
+1. **Tests existentes**: `pnpm test` sin regresiones en `bindComponent.test.ts`, `nestedProperties.test.ts`, `selectiveRendering.test.ts`, `reactiveProxy.test.ts`.
+2. **Ejemplo nuevo**: levantar `examples/nested-prop-component` y confirmar que los errores aparecen al hacer click en "Bet".
+3. **Ejemplo existente**: levantar `examples/components` y confirmar que no hay regresiones.
+
+---
+
+## Archivos impactados
+
+### `examples/nested-prop-component/` (nuevo)
+- `index.html`, `main.ts`, `vite.config.ts`, `package.json`, `.npmrc`, `routes.ts`
+- `src/bet.pelela`, `src/bet.ts`, `src/betModel.ts`
+- `src/error-list.pelela`, `src/error-list.ts`
+
+### `packages/core/src/bindings/`
+- **[MODIFY]** `bindComponent.ts` — Fix A (nested paths) + Fix B (array mutation)
+- **[MODIFY]** `types.ts` — agregar `renderChild` a `ComponentBinding`
+- **[MODIFY]** `bindComponent.test.ts` — tests A y B + test de re-render DOM
+- **[MODIFY]** `reactiveProxy.ts` — detectar mutaciones de propiedades de arrays
+
+---
+
+## Verification Plan
+
+### Automated Tests
+```bash
+# Desde la raíz del monorepo
+pnpm test
+# O específicamente:
+pnpm --filter @pelelajs/core test -- bindComponent
+```
+
+### Manual Verification
+- Levantar `examples/nested-prop-component` y verificar comportamiento en browser
+- Levantar `examples/components` y verificar que no hay regresiones

--- a/plans/nested-prop-reactivity.md
+++ b/plans/nested-prop-reactivity.md
@@ -188,8 +188,10 @@ Para detectar mutaciones de propiedades de arrays (como `.length = 0`), siempre 
     const oldValue = Reflect.get(targetObject, propertyKey, receiver)
 
 +   // Always notify for array property assignments (like .length) to catch in-place mutations
-+   const isArrayProperty = Array.isArray(targetObject) && typeof propertyKey === 'string'
-+   if (!isArrayProperty && oldValue === value) {
++   const isArrayMutation =
+      Array.isArray(targetObject) &&
+      (propertyKey === 'length' || (typeof propertyKey === 'string' && /^\d+$/.test(propertyKey)))
++   if (!isArrayMutation && oldValue === value) {
 +     return true
 +   }
 

--- a/plans/new-command-component-flag.md
+++ b/plans/new-command-component-flag.md
@@ -1,0 +1,116 @@
+# Plan: Flag `--component` en el comando `pelela new`
+
+## Contexto
+
+El comando `pelela new <ComponentName>` genera tres archivos: `.ts`, `.pelela` y `.css`. El template `.pelela` generado actualmente tiene dos problemas:
+
+1. Envuelve todo en un `<div>` innecesario que no aporta semántica.
+2. Solo genera `<pelela>` como tag raíz, pero no hay forma de generar un componente hijo (`<component>`) desde el CLI.
+
+## Cambios propuestos
+
+### `tools/pelela-cli/src/utils/componentFiles.ts`
+
+#### Cambio 1 — Eliminar el `<div>` wrapper y parametrizar el tag raíz
+
+Actualmente:
+```typescript
+const content = `<div>
+  <pelela view-model="${componentName}">
+    <h1>${componentName} Component</h1>
+    <!-- Add your template here -->
+  </pelela>
+</div>
+`
+```
+
+Propuesta: `createPelelaFile` recibe un `rootTag: 'pelela' | 'component'` (default: `'pelela'`):
+
+```typescript
+export function createPelelaFile(name: string, targetDir: string, rootTag: 'pelela' | 'component' = 'pelela'): void {
+  ...
+  const content = `<${rootTag} view-model="${componentName}">
+  <h1>${componentName} Component</h1>
+  <!-- Add your template here -->
+</${rootTag}>
+`
+```
+
+---
+
+### `tools/pelela-cli/src/commands/new.ts`
+
+#### Cambio 2 — Agregar `component` a `NewCommandOptions` y propagarlo
+
+```typescript
+export interface NewCommandOptions {
+  componentName: string
+  css?: boolean
+  component?: boolean   // ← nuevo
+}
+```
+
+Y pasarlo a `createPelelaFile`:
+```typescript
+const rootTag = options.component ? 'component' : 'pelela'
+createPelelaFile(componentName, targetDir, rootTag)
+```
+
+---
+
+### `tools/pelela-cli/src/index.ts`
+
+#### Cambio 3 — Registrar la opción `-c, --component` en Commander
+
+```typescript
+.option('-c, --component', t('commands.new.options.component'))
+.action(async (componentName: string, options: { css: boolean; component: boolean }) => {
+  await newCommand({ componentName, css: options.css, component: options.component })
+})
+```
+
+---
+
+### `tools/pelela-cli/src/locales/es.json` y `en.json`
+
+#### Cambio 4 — Agregar la clave i18n para la nueva opción
+
+```json
+"options": {
+  "noCss": "No generar el archivo CSS",
+  "component": "Generar con tag raíz <component> en lugar de <pelela>"
+}
+```
+
+---
+
+### `tools/pelela-cli/test/commands/new.test.ts`
+
+#### Cambio 5 — Actualizar tests existentes y agregar nuevos
+
+- **Actualizar** los tests existentes que chequeaban `<div>` como parte del contenido del `.pelela` (ya no existirá).
+- **Agregar** test: sin `--component`, el template usa `<pelela>`.
+- **Agregar** test: con `component: true`, el template usa `<component>`.
+- **Agregar** test: sin `--component`, NO se agrega el componente a routes.ts.
+- **Agregar** test: con `component: true`, NO se agrega el componente a routes.ts.
+
+---
+
+## Archivos impactados
+
+| Archivo | Acción |
+|---|---|
+| `src/utils/componentFiles.ts` | Modificar `createPelelaFile`: quitar `<div>`, agregar parámetro `rootTag` |
+| `src/commands/new.ts` | Agregar `component?: boolean` a `NewCommandOptions`, propagar a `createPelelaFile` |
+| `src/index.ts` | Registrar `-c, --component` en Commander |
+| `src/locales/es.json` | Agregar clave `commands.new.options.component` |
+| `src/locales/en.json` | Agregar clave `commands.new.options.component` |
+| `test/commands/new.test.ts` | Actualizar tests existentes + agregar tests para la nueva opción |
+
+## Verificación
+
+```bash
+pnpm --filter pelela-cli test
+pnpm run biome:check
+pnpm typecheck
+```

--- a/plans/prop-constants-validation.md
+++ b/plans/prop-constants-validation.md
@@ -1,0 +1,342 @@
+# Feature: Const bindings y validación por campo
+
+## Contexto
+
+Actualmente el framework soporta pasar propiedades dinámicas desde el padre al hijo usando `prop-*` (one-way binding) y `link-*` (two-way binding). Sin embargo, no soporta pasar valores constantes al hijo sin registrarlos como bindings reactivos, y no hay una forma estandarizada de validar campos individuales.
+
+## Objetivos
+
+1. **Soporte de constantes no reactivas**: Permitir pasar strings o números como valores constantes con `const-*`
+2. **Validación por campo**: Usar el componente validator (renombrado de error-list) para mostrar errores específicos debajo de cada input, filtrando por `fieldName`
+3. **Ejemplo actualizado**: Agregar input de fecha al ejemplo nested-prop-component con validación
+
+---
+
+## Plan iterativo
+
+> [!CAUTION]
+> **REGLA ESTRICTA**: Al finalizar cada checkpoint, DEBO DETENERME y esperar la confirmación explícita ("OK") del usuario antes de avanzar al siguiente. NO debo ejecutar ni editar archivos del siguiente checkpoint hasta recibir luz verde.
+
+### Checkpoint 1 — Modificar ejemplo nested-prop-component
+
+#### [MODIFY] `examples/nested-prop-component/src/bet.pelela`
+
+Agregar input de fecha antes del input de monto y usar validators específicos:
+
+```html
+<pelela view-model="Bet">
+  <div class="container">
+    <h1>Place Bet</h1>
+    <div class="form-group">
+      <label for="date">Date:</label>
+      <input id="date" type="date" bind-value="bet.date" />
+      <validator const-field-name="date" prop-errors="bet.errors"></validator>
+    </div>
+    <div class="form-group">
+      <label for="amount">Amount:</label>
+      <input id="amount" type="number" bind-value="bet.amount" placeholder="Enter your bet..." />
+      <validator const-field-name="amount" prop-errors="bet.errors"></validator>
+    </div>
+    <button click="place">Bet</button>
+  </div>
+</pelela>
+```
+
+#### [MODIFY] `examples/nested-prop-component/src/betModel.ts`
+
+Agregar campo `date` y validación:
+
+```typescript
+type ValidationError = {
+  fieldName: string
+  errorMessage: string
+}
+
+export class BetModel {
+  date: Date | null = null
+  amount = ''
+  errors: ValidationError[] = []
+
+  validate() {
+    this.errors.length = 0
+    if (!this.date) {
+      this.errors.push({
+        fieldName: 'date',
+        errorMessage: 'Date is required',
+      })
+    }
+    if (!this.amount) {
+      this.errors.push({
+        fieldName: 'amount',
+        errorMessage: 'You must enter a bet amount',
+      })
+    } else if (Number(this.amount) <= 0) {
+      this.errors.push({
+        fieldName: 'amount',
+        errorMessage: 'Amount must be greater than zero',
+      })
+    }
+  }
+}
+```
+
+#### [MODIFY] `examples/nested-prop-component/src/error-list.pelela` → `validator.pelela`
+
+Renombrar archivo y actualizar template para mostrar solo el mensaje de cada error filtrado por `fieldName`:
+
+```html
+<pelela view-model="Validator">
+  <ul class="error-list" if="filteredErrors.length">
+    <li for-each="error of filteredErrors">
+      <span bind-content="error.errorMessage"></span>
+    </li>
+  </ul>
+</pelela>
+```
+
+#### [MODIFY] `examples/nested-prop-component/src/error-list.ts` → `validator.ts`
+
+Renombrar archivo y actualizar ViewModel para filtrar errores por `fieldName`:
+
+```typescript
+type ValidationError = {
+  fieldName: string
+  errorMessage: string
+}
+
+export class Validator {
+  fieldName = ''
+  errors: ValidationError[] = []
+
+  get filteredErrors(): ValidationError[] {
+    return this.errors.filter((error) => error.fieldName === this.fieldName)
+  }
+}
+```
+
+#### [NO CHANGE] `examples/nested-prop-component/src/bet.ts`
+
+No modificar `bet.ts` para registrar el componente renombrado. El auto-register registra `validator` automáticamente a partir de los archivos renombrados.
+
+**Punto de control**: pedir al usuario ejecutar la verificación del ejemplo. El ejemplo debería compilar y visualizarse en el browser (aunque la validación no funciona aún porque falta el soporte de `const-*`). ✓ → pasar al Checkpoint 2.
+
+---
+
+### Checkpoint 2 — Soporte de `const-*` no reactivo
+
+#### [MODIFY] `packages/core/src/commons/dom.ts`
+
+Agregar el prefijo `const-*` como atributo válido de componentes. A diferencia de `prop-*` y `link-*`, `const-*` no representa un binding reactivo:
+
+```typescript
+export const LINK_PREFIX = 'link-'
+export const PROP_PREFIX = 'prop-'
+export const CONST_PREFIX = 'const-'
+
+export function isValidComponentAttribute(attrName: string): boolean {
+  return (
+    attrName.startsWith(LINK_PREFIX) ||
+    attrName.startsWith(PROP_PREFIX) ||
+    attrName.startsWith(CONST_PREFIX) ||
+    isValidBindingAttrForComponent(attrName)
+  )
+}
+```
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.ts`
+
+Agregar extracción de constantes separada de `prop-*`. Las constantes se inicializan una sola vez y no deben entrar en `ComponentBinding.mappings`:
+
+```typescript
+import {
+  CONST_PREFIX,
+  LINK_PREFIX,
+  PROP_PREFIX,
+  ...
+} from '../commons/dom'
+
+function isConst(attr: Attr): boolean {
+  return attr.name.startsWith(CONST_PREFIX)
+}
+
+function isNumberConstant(value: string): boolean {
+  return value.trim() !== '' && !Number.isNaN(Number(value))
+}
+
+function parseConstant(value: string): string | number {
+  return isNumberConstant(value) ? Number(value) : value
+}
+
+function extractConstantBindings(
+  attributes: NamedNodeMap,
+): Array<{ childKey: string; value: string | number }> {
+  return Array.from(attributes)
+    .filter(isConst)
+    .map((attr) => ({
+      childKey: toCamelCase(attr.name.substring(CONST_PREFIX.length)),
+      value: parseConstant(attr.value),
+    }))
+}
+```
+
+`extractOneWayBindings` debe seguir devolviendo solo bindings dinámicos:
+
+```typescript
+function extractOneWayBindings(
+  attributes: NamedNodeMap,
+): Array<{ parentKey: string; childKey: string }> {
+  return Array.from(attributes)
+    .filter(isProps)
+    .map((attr) => ({
+      childKey: toCamelCase(attr.name.substring(PROP_PREFIX.length)),
+      parentKey: attr.value,
+    }))
+}
+```
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.ts` — `setupComponentBindings`
+
+Actualizar el setup para asignar constantes antes de configurar los bindings reactivos:
+
+```typescript
+function getValidatedParentValue(parentViewModel: ViewModel, parentKey: string): unknown {
+  return parentKey.split('.').reduce((current: unknown, segment) => {
+    if (!isObject(current) || !hasProperty(current as object, segment)) {
+      throw new Error(...)
+    }
+
+    return (current as Record<string, unknown>)[segment]
+  }, parentViewModel)
+}
+
+const constantBindings = extractConstantBindings(element.attributes)
+const linkBindings = extractLinkBindings(element.attributes)
+const oneWayBindings = extractOneWayBindings(element.attributes)
+const allMappings = [...linkBindings, ...oneWayBindings]
+
+constantBindings.forEach(({ childKey, value }) => {
+  if (isUnsafeKey(childKey)) {
+    throw new Error(...)
+  }
+
+  instance[childKey] = value
+})
+
+allMappings.forEach(({ parentKey, childKey }) => {
+  if (isUnsafeKey(parentKey) || isUnsafeKey(childKey)) {
+    throw new Error(...)
+  }
+
+  instance[childKey] = getValidatedParentValue(parentViewModel, parentKey)
+})
+```
+
+`ComponentBinding.mappings` debe mantenerse como la lista de bindings reactivos del padre (`prop-*` y `link-*`). Las constantes quedan fuera de esa lista, por lo que no se registran como dependencias y no participan de `renderComponentBindings`.
+
+**Punto de control**: pedir al usuario ejecutar los tests existentes. Si pasan, ✓ → pasar al Checkpoint 3.
+
+---
+
+### Checkpoint 3 — Tests para `const-*`
+
+#### [MODIFY] `packages/core/src/bindings/bindComponent.test.ts`
+
+Agregar tests para verificar que las constantes se pasan correctamente y no participan de la reactividad:
+
+```typescript
+describe('const-* bindings', () => {
+  it('should pass string constant as child value', () => {
+    class ChildVM {
+      message = ''
+    }
+    defineComponent('child-comp', ChildVM, '<component view-model="ChildVM"><span bind-content="message"></span></component>')
+
+    container.innerHTML = '<child-comp const-message="Hello"></child-comp>'
+
+    const parentVM = createReactiveViewModel({}, () => {})
+    const bindings = setupComponentBindings(container, parentVM)
+
+    const childVM = bindings[0].childViewModel as unknown as ChildVM
+    expect(childVM.message).toBe('Hello')
+    expect(bindings[0].mappings).toEqual([])
+  })
+
+  it('should pass number constant as child value', () => {
+    class ChildVM {
+      count = 0
+    }
+    defineComponent('child-comp', ChildVM, '<component view-model="ChildVM"><span bind-content="count"></span></component>')
+
+    container.innerHTML = '<child-comp const-count="42"></child-comp>'
+
+    const parentVM = createReactiveViewModel({}, () => {})
+    const bindings = setupComponentBindings(container, parentVM)
+
+    const childVM = bindings[0].childViewModel as unknown as ChildVM
+    expect(childVM.count).toBe(42)
+    expect(bindings[0].mappings).toEqual([])
+  })
+
+  it('should still support dynamic prop bindings', () => {
+    class ChildVM {
+      message = ''
+    }
+    defineComponent('child-comp', ChildVM, '<component view-model="ChildVM"><span bind-content="message"></span></component>')
+
+    container.innerHTML = '<child-comp prop-message="parentMessage"></child-comp>'
+
+    const parentVM = createReactiveViewModel({ parentMessage: 'Dynamic' }, () => {})
+    const bindings = setupComponentBindings(container, parentVM)
+
+    const childVM = bindings[0].childViewModel as unknown as ChildVM
+    expect(childVM.message).toBe('Dynamic')
+    expect(bindings[0].mappings).toEqual([{ parentKey: 'parentMessage', childKey: 'message' }])
+  })
+})
+```
+
+**Punto de control**: pedir al usuario ejecutar los tests nuevos. Si pasan, ✓ → pasar al Checkpoint 4.
+
+---
+
+### Checkpoint 4 — Verificación integral
+
+1. **Tests existentes**: pedir al usuario ejecutar `pnpm run test --run` y confirmar que no hay regresiones
+2. **Ejemplo actualizado**: levantar `examples/nested-prop-component` y verificar que:
+   - Los inputs de fecha y monto funcionan
+   - Los validators muestran errores específicos debajo de cada input
+   - Las constantes con `const-*` inicializan valores y no participan de la reactividad
+3. **Ejemplo existente**: levantar `examples/components` y verificar que no hay regresiones
+
+---
+
+## Archivos impactados
+
+### `examples/nested-prop-component/`
+- **[MODIFY]** `src/bet.pelela` — agregar input de fecha y validators
+- **[MODIFY]** `src/betModel.ts` — agregar campo date y validación
+- **[RENAME]** `src/error-list.pelela` → `src/validator.pelela` — renombrar y actualizar template
+- **[RENAME]** `src/error-list.ts` → `src/validator.ts` — renombrar y actualizar ViewModel
+
+### `packages/core/src/commons/`
+- **[MODIFY]** `dom.ts` — agregar `CONST_PREFIX` y permitir atributos `const-*`
+
+### `packages/core/src/bindings/`
+- **[MODIFY]** `bindComponent.ts` — soporte de constantes no reactivas con `const-*`
+- **[MODIFY]** `bindComponent.test.ts` — tests para `const-*`
+
+---
+
+## Verification Plan
+
+### Automated Tests
+```bash
+# Pedir al usuario ejecutar desde la raíz del monorepo
+pnpm run test --run
+# O específicamente
+pnpm --filter @pelelajs/core test -- bindComponent
+```
+
+### Manual Verification
+- Levantar `examples/nested-prop-component` y verificar comportamiento en browser
+- Levantar `examples/components` y verificar que no hay regresiones

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,22 @@ importers:
         specifier: 7.2.4
         version: 7.2.4(@types/node@24.10.1)(jiti@2.7.0)(tsx@4.21.0)
 
+  examples/nested-prop-component:
+    dependencies:
+      pelelajs:
+        specifier: workspace:*
+        version: link:../../packages/core
+      vite-plugin-pelelajs:
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-pelelajs
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 7.2.4
+        version: 7.2.4(@types/node@24.10.1)(tsx@4.21.0)
+
   examples/routing:
     dependencies:
       pelelajs:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.2.4
-        version: 7.2.4(@types/node@24.10.1)(tsx@4.21.0)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.7.0)(tsx@4.21.0)
 
   examples/routing:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       commander:
         specifier: 12.1.0
         version: 12.1.0
+      devalue:
+        specifier: ^5.1.0
+        version: 5.8.1
       i18next:
         specifier: ^23.7.6
         version: 23.16.8
@@ -1952,6 +1955,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -5531,6 +5537,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  devalue@5.8.1: {}
 
   diff@5.0.0: {}
 

--- a/tools/pelela-cli/src/commands/new.ts
+++ b/tools/pelela-cli/src/commands/new.ts
@@ -15,10 +15,11 @@ import { t } from '../utils/i18n'
 export interface NewCommandOptions {
   componentName: string
   css?: boolean
+  component?: boolean
 }
 
 export async function newCommand(options: NewCommandOptions): Promise<void> {
-  const { componentName, css = true } = options
+  const { componentName, css = true, component = false } = options
 
   if (!componentName) {
     throw new Error(t('commands.new.error.nameEmpty'))
@@ -39,7 +40,7 @@ export async function newCommand(options: NewCommandOptions): Promise<void> {
 
   try {
     createTsFile(componentName, targetDir)
-    createPelelaFile(componentName, targetDir)
+    createPelelaFile(componentName, targetDir, component ? 'component' : 'pelela')
     if (css) {
       createCssFile(componentName, targetDir)
     }

--- a/tools/pelela-cli/src/commands/new.ts
+++ b/tools/pelela-cli/src/commands/new.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { basename, join } from 'node:path'
+import { join } from 'node:path'
 import chalk from 'chalk'
 import {
   createCssFile,
@@ -8,6 +8,7 @@ import {
   getComponentTargetDir,
   normalizeComponentName,
   toKebabCase,
+  validateBasename,
 } from '../utils/componentFiles'
 import { t } from '../utils/i18n'
 
@@ -23,10 +24,7 @@ export async function newCommand(options: NewCommandOptions): Promise<void> {
     throw new Error(t('commands.new.error.nameEmpty'))
   }
 
-  const basenameComponentName = basename(componentName)
-  if (!/^[A-Z][a-zA-Z0-9]*$/.test(basenameComponentName)) {
-    throw new Error(t('commands.new.error.nameInvalid'))
-  }
+  validateBasename(componentName, 'commands.new.error.nameInvalid')
 
   const targetDir = getComponentTargetDir()
   const normalizedName = normalizeComponentName(componentName, targetDir)

--- a/tools/pelela-cli/src/commands/rename.ts
+++ b/tools/pelela-cli/src/commands/rename.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { dirname, join } from 'node:path'
 import chalk from 'chalk'
 import {
   findComponentFile,
@@ -9,6 +9,7 @@ import {
   renameTsFile,
   toKebabCase,
   updateImports,
+  validateBasename,
 } from '../utils/componentFiles'
 import { t } from '../utils/i18n'
 
@@ -27,10 +28,8 @@ export async function renameCommand(options: RenameCommandOptions): Promise<void
     throw new Error(t('commands.rename.error.newNameEmpty'))
   }
 
-  const basenameNewComponentName = basename(newComponentName)
-  if (!/^[A-Z][a-zA-Z0-9]*$/.test(basenameNewComponentName)) {
-    throw new Error(t('commands.rename.error.nameInvalid'))
-  }
+  validateBasename(oldComponentName, 'commands.rename.error.nameInvalid')
+  validateBasename(newComponentName, 'commands.rename.error.nameInvalid')
 
   const oldTsFile = findComponentFile(oldComponentName, '.ts')
   if (!oldTsFile) {

--- a/tools/pelela-cli/src/index.ts
+++ b/tools/pelela-cli/src/index.ts
@@ -44,9 +44,10 @@ async function main(): Promise<void> {
     .command('new <path/componentName>')
     .description(t('commands.new.description'))
     .option('--no-css', t('commands.new.options.noCss'))
-    .action(async (componentName: string, options: { css: boolean }) => {
+    .option('-c, --component', t('commands.new.options.component'))
+    .action(async (componentName: string, options: { css: boolean; component: boolean }) => {
       try {
-        await newCommand({ componentName, css: options.css })
+        await newCommand({ componentName, css: options.css, component: options.component })
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error)
         warn(chalk.red.bold(`${t('errors.prefix')} `), chalk.red(errorMessage))

--- a/tools/pelela-cli/src/index.ts
+++ b/tools/pelela-cli/src/index.ts
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
     })
 
   program
-    .command('rename <oldComponentName> <newComponentName>')
+    .command('rename <path/oldComponentName> <path/newComponentName>')
     .description(t('commands.rename.description'))
     .action(async (oldComponentName: string, newComponentName: string) => {
       try {

--- a/tools/pelela-cli/src/locales/en.json
+++ b/tools/pelela-cli/src/locales/en.json
@@ -19,7 +19,7 @@
       }
     },
     "new": {
-      "description": "✨ Create a new PelelaJS component",
+      "description": "✨ Create a new component (a path can be specified for the location)",
       "options": {
         "noCss": "Do not generate a CSS file"
       },
@@ -34,7 +34,7 @@
       }
     },
     "rename": {
-      "description": "🔄 Rename an existing component",
+      "description": "🔄 Rename a component (use path/name to disambiguate if necessary)",
       "error": {
         "oldNameEmpty": "Current component name cannot be empty",
         "newNameEmpty": "New component name cannot be empty",

--- a/tools/pelela-cli/src/locales/en.json
+++ b/tools/pelela-cli/src/locales/en.json
@@ -21,7 +21,8 @@
     "new": {
       "description": "✨ Create a new component (a path can be specified for the location)",
       "options": {
-        "noCss": "Do not generate a CSS file"
+        "noCss": "Do not generate a CSS file",
+        "component": "Generate with root tag <component> instead of <pelela>"
       },
       "error": {
         "nameEmpty": "Component name cannot be empty",

--- a/tools/pelela-cli/src/locales/es.json
+++ b/tools/pelela-cli/src/locales/es.json
@@ -21,7 +21,8 @@
     "new": {
       "description": "✨ Crear un nuevo componente (se puede especificar un path para la ubicación)",
       "options": {
-        "noCss": "No generar el archivo CSS"
+        "noCss": "No generar el archivo CSS",
+        "component": "Generar con tag raíz <component> en lugar de <pelela>"
       },
       "error": {
         "nameEmpty": "El nombre del componente no puede estar vacío",

--- a/tools/pelela-cli/src/locales/es.json
+++ b/tools/pelela-cli/src/locales/es.json
@@ -19,7 +19,7 @@
       }
     },
     "new": {
-      "description": "✨ Crear un nuevo componente PelelaJS",
+      "description": "✨ Crear un nuevo componente (se puede especificar un path para la ubicación)",
       "options": {
         "noCss": "No generar el archivo CSS"
       },
@@ -34,7 +34,7 @@
       }
     },
     "rename": {
-      "description": "🔄 Renombrar un componente existente",
+      "description": "🔄 Renombrar un componente (usar path/nombre para desambiguar si es necesario)",
       "error": {
         "oldNameEmpty": "El nombre actual del componente no puede estar vacío",
         "newNameEmpty": "El nuevo nombre del componente no puede estar vacío",

--- a/tools/pelela-cli/src/utils/componentFiles.ts
+++ b/tools/pelela-cli/src/utils/componentFiles.ts
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
+import { t } from './i18n'
 
 const SRC_DIR = 'src'
 
@@ -16,30 +17,44 @@ export function getComponentTargetDir(): string {
   return existsSync(SRC_DIR) ? SRC_DIR : '.'
 }
 
+export function validateBasename(name: string, errorKey: string): void {
+  const nameBasename = basename(name)
+  if (!/^[A-Z][a-zA-Z0-9]*$/.test(nameBasename)) {
+    throw new Error(t(errorKey))
+  }
+}
+
 export function findComponentFile(componentName: string, extension: string): string | null {
   const targetDir = getComponentTargetDir()
-  const kebabName = toKebabCase(componentName)
-  const fileName = `${kebabName}${extension}`
+  const normalizedInput = componentName.replace(/\\/g, '/')
+  const kebabInput = normalizedInput
+    .split('/')
+    .map((part) => toKebabCase(part))
+    .join('/')
+  const searchFileName = basename(kebabInput) + extension
   const ignoredDirs = ['node_modules', 'dist']
+
+  const matchesPath = (fullPath: string): boolean => {
+    const normalizedFullPath = fullPath.replace(/\\/g, '/')
+    return normalizedFullPath.endsWith(`${kebabInput}${extension}`)
+  }
 
   function searchDirectory(dir: string): string | null {
     if (!existsSync(dir)) return null
 
-    const files = readdirSync(dir)
-    const validFiles = files.filter((file) => !ignoredDirs.includes(file))
-
-    for (const file of validFiles) {
-      const fullPath = join(dir, file)
-      const stat = statSync(fullPath)
-
-      if (stat.isDirectory()) {
-        const result = searchDirectory(fullPath)
-        if (result !== null) return result
-      } else if (file === fileName) {
-        return fullPath
-      }
-    }
-    return null
+    return (
+      readdirSync(dir)
+        .filter((file) => !ignoredDirs.includes(file))
+        .map((file) => {
+          const fullPath = join(dir, file)
+          return statSync(fullPath).isDirectory()
+            ? searchDirectory(fullPath)
+            : file === searchFileName && matchesPath(fullPath)
+              ? fullPath
+              : null
+        })
+        .find((result) => result !== null) ?? null
+    )
   }
 
   return searchDirectory(targetDir)

--- a/tools/pelela-cli/src/utils/componentFiles.ts
+++ b/tools/pelela-cli/src/utils/componentFiles.ts
@@ -174,16 +174,18 @@ export function createTsFile(name: string, targetDir: string): void {
   writeFileSync(path, content)
 }
 
-export function createPelelaFile(name: string, targetDir: string): void {
+export function createPelelaFile(
+  name: string,
+  targetDir: string,
+  rootTag: 'pelela' | 'component' = 'pelela',
+): void {
   const { path, normalizedName } = prepareFile({ name, extension: 'pelela', targetDir })
 
   const componentName = basename(normalizedName)
-  const content = `<div>
-  <pelela view-model="${componentName}">
-    <h1>${componentName} Component</h1>
-    <!-- Add your template here -->
-  </pelela>
-</div>
+  const content = `<${rootTag} view-model="${componentName}">
+  <h1>${componentName} Component</h1>
+  <!-- Add your template here -->
+</${rootTag}>
 `
   writeFileSync(path, content)
 }

--- a/tools/pelela-cli/src/utils/componentFiles.ts
+++ b/tools/pelela-cli/src/utils/componentFiles.ts
@@ -8,7 +8,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { t } from './i18n'
 
 const SRC_DIR = 'src'
@@ -18,6 +18,10 @@ export function getComponentTargetDir(): string {
 }
 
 export function validateBasename(name: string, errorKey: string): void {
+  if (isAbsolute(name) || name.includes('..')) {
+    throw new Error(t(errorKey))
+  }
+
   const nameBasename = basename(name)
   if (!/^[A-Z][a-zA-Z0-9]*$/.test(nameBasename)) {
     throw new Error(t(errorKey))
@@ -35,24 +39,29 @@ export function findComponentFile(componentName: string, extension: string): str
   const ignoredDirs = ['node_modules', 'dist']
 
   const matchesPath = (fullPath: string): boolean => {
-    const normalizedFullPath = fullPath.replace(/\\/g, '/')
+    const normalizedFullPath = relative(resolve(targetDir), resolve(fullPath)).replace(/\\/g, '/')
     return normalizedFullPath.endsWith(`${kebabInput}${extension}`)
   }
 
   function searchDirectory(dir: string): string | null {
     if (!existsSync(dir)) return null
 
+    const findMatchInEntry = (file: string): string | null => {
+      const fullPath = join(dir, file)
+      const isDirectory = statSync(fullPath).isDirectory()
+
+      if (isDirectory) {
+        return searchDirectory(fullPath)
+      }
+
+      const isMatch = file === searchFileName && matchesPath(fullPath)
+      return isMatch ? fullPath : null
+    }
+
     return (
       readdirSync(dir)
         .filter((file) => !ignoredDirs.includes(file))
-        .map((file) => {
-          const fullPath = join(dir, file)
-          return statSync(fullPath).isDirectory()
-            ? searchDirectory(fullPath)
-            : file === searchFileName && matchesPath(fullPath)
-              ? fullPath
-              : null
-        })
+        .map(findMatchInEntry)
         .find((result) => result !== null) ?? null
     )
   }

--- a/tools/pelela-cli/src/utils/templates.ts
+++ b/tools/pelela-cli/src/utils/templates.ts
@@ -26,9 +26,9 @@ function copyRecursive(src: string, dest: string): void {
     if (!existsSync(dest)) {
       mkdirSync(dest, { recursive: true })
     }
-    readdirSync(src).forEach((child) => {
-      if (child !== 'node_modules') {
-        copyRecursive(join(src, child), join(dest, child))
+    readdirSync(src, { withFileTypes: true }).forEach((dirent) => {
+      if (dirent.name !== 'node_modules') {
+        copyRecursive(join(src, dirent.name), join(dest, dirent.name))
       }
     })
   } else {

--- a/tools/pelela-cli/templates/base-template-for-cli/.github/workflows/ci.yml
+++ b/tools/pelela-cli/templates/base-template-for-cli/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack and install pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.4.0 --activate
+          pnpm --version
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Biome check
+        run: pnpm exec biome check .
+
+      - name: Run TypeScript typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Build project
+        run: pnpm build

--- a/tools/pelela-cli/templates/base-template-for-cli/package.json
+++ b/tools/pelela-cli/templates/base-template-for-cli/package.json
@@ -10,6 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "biome check .",
+    "lint:fix": "biome format --write .",
     "format": "biome format --write ."
   },
   "keywords": [],
@@ -21,7 +22,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "typescript": "5.9.3",
-    "vite": "7.2.4",
+    "vite": "7.3.2",
     "vite-plugin-pelelajs": "latest"
   },
   "engines": {

--- a/tools/pelela-cli/templates/base-template-for-cli/package.json
+++ b/tools/pelela-cli/templates/base-template-for-cli/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "biome check .",
-    "lint:fix": "biome format --write .",
+    "lint:fix": "biome check --write .",
     "format": "biome format --write ."
   },
   "keywords": [],

--- a/tools/pelela-cli/templates/base-template-for-cli/pnpm-workspace.yaml
+++ b/tools/pelela-cli/templates/base-template-for-cli/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/tools/pelela-cli/test/commands/init.integration.test.ts
+++ b/tools/pelela-cli/test/commands/init.integration.test.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from 'node:crypto'
+import { existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { initCommand } from '../../src/commands/init'
+import { initializeI18n } from '../../src/utils/i18n'
+
+describe('initCommand (Integration)', () => {
+  const testDir = `pelela-init-test-${randomUUID()}`
+
+  beforeAll(async () => {
+    await initializeI18n('en')
+  })
+
+  afterAll(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('copies .gitignore to the initialized project', async () => {
+    await initCommand({ projectName: testDir })
+
+    const gitignorePath = join(testDir, '.gitignore')
+    expect(existsSync(gitignorePath)).toBe(true)
+
+    rmSync(testDir, { recursive: true, force: true })
+  })
+})

--- a/tools/pelela-cli/test/commands/init.integration.test.ts
+++ b/tools/pelela-cli/test/commands/init.integration.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { existsSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { initCommand } from '../../src/commands/init'
@@ -24,6 +24,16 @@ describe('initCommand (Integration)', () => {
     const gitignorePath = join(testDir, '.gitignore')
     expect(existsSync(gitignorePath)).toBe(true)
 
-    rmSync(testDir, { recursive: true, force: true })
+    const packageJsonPath = join(testDir, 'package.json')
+    expect(existsSync(packageJsonPath)).toBe(true)
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+    expect(packageJson.name).toBe(testDir)
+
+    const biomeJsonPath = join(testDir, 'biome.json')
+    expect(existsSync(biomeJsonPath)).toBe(true)
+
+    expect(existsSync(join(testDir, 'src'))).toBe(true)
+    expect(existsSync(join(testDir, 'index.html'))).toBe(true)
+    expect(existsSync(join(testDir, 'main.ts'))).toBe(true)
   })
 })

--- a/tools/pelela-cli/test/commands/new.test.ts
+++ b/tools/pelela-cli/test/commands/new.test.ts
@@ -11,7 +11,7 @@ beforeAll(async () => {
 })
 
 afterEach(() => {
-  vi.clearAllMocks()
+  vi.resetAllMocks()
 })
 
 describe('newCommand', () => {
@@ -46,7 +46,11 @@ describe('newCommand', () => {
     )
     expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('src/my-component.pelela'),
-      expect.stringContaining('view-model="MyComponent"'),
+      expect.stringMatching(/^<pelela view-model="MyComponent">/),
+    )
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('src/my-component.pelela'),
+      expect.stringContaining('<div>'),
     )
     expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('src/my-component.css'),
@@ -65,7 +69,7 @@ describe('newCommand', () => {
     )
     expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
       'my-component.pelela',
-      expect.stringContaining('view-model="MyComponent"'),
+      expect.stringMatching(/^<pelela view-model="MyComponent">/),
     )
     expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
       'my-component.css',
@@ -104,6 +108,17 @@ describe('newCommand', () => {
 
     await expect(newCommand({ componentName: 'MyComponent' })).rejects.toThrow(
       t('commands.new.error.creationFailed', { error: 'Write failed' }),
+    )
+  })
+
+  it('uses <component> tag when component option is true', async () => {
+    mockedFs.existsSync.mockImplementation((path) => path === 'src')
+
+    await newCommand({ componentName: 'MyComponent', component: true })
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('src/my-component.pelela'),
+      expect.stringMatching(/^<component view-model="MyComponent">/),
     )
   })
 })

--- a/tools/pelela-cli/test/commands/rename.test.ts
+++ b/tools/pelela-cli/test/commands/rename.test.ts
@@ -53,6 +53,12 @@ describe('renameCommand (Integration)', () => {
     ).rejects.toThrow(t('commands.rename.error.nameInvalid'))
   })
 
+  it('throws for invalid old name', async () => {
+    await expect(
+      renameCommand({ oldComponentName: 'old', newComponentName: 'New' }),
+    ).rejects.toThrow(t('commands.rename.error.nameInvalid'))
+  })
+
   it('throws if old files do not exist', async () => {
     await expect(
       renameCommand({ oldComponentName: 'Old', newComponentName: 'New' }),

--- a/tools/pelela-cli/tsup.config.ts
+++ b/tools/pelela-cli/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   target: 'node22',
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
+  publicDir: 'templates',
 })

--- a/tools/pelela-vscode/src/providers/completionProvider.ts
+++ b/tools/pelela-vscode/src/providers/completionProvider.ts
@@ -60,7 +60,7 @@ function addHtmlAttributeCompletions(items: vscode.CompletionItem[]): void {
   })
 }
 
-function addPelelaAttributeCompletions(items: vscode.CompletionItem[]): void {
+export function addPelelaAttributeCompletions(items: vscode.CompletionItem[]): void {
   const attrNames = getPelelaAttributes()
 
   const attributeSnippets: Record<string, { text: string; detail: string }> = {

--- a/tools/pelela-vscode/src/providers/completionProvider.ts
+++ b/tools/pelela-vscode/src/providers/completionProvider.ts
@@ -97,6 +97,11 @@ function addPelelaAttributeCompletions(items: vscode.CompletionItem[]): void {
       item.insertText = new vscode.SnippetString(`${name}="\${1:propiedad}"`)
       item.detail = 'Pelela: binding al view model'
       item.sortText = `!0_${name}`
+    } else if (name.startsWith('const-')) {
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: VSCode snippet syntax
+      item.insertText = new vscode.SnippetString('const-${1:field-name}="${2:value}"')
+      item.detail = 'Pelela: valor constante para un componente'
+      item.sortText = `!0_${name}`
     }
 
     items.push(item)

--- a/tools/pelela-vscode/src/providers/definitionProvider.ts
+++ b/tools/pelela-vscode/src/providers/definitionProvider.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { isPelelaRootTag, isStandardHtmlTag } from 'pelelajs/dom'
 import * as vscode from 'vscode'
 import {
   findClassDefinition,
@@ -11,18 +14,65 @@ import { findViewModelFile } from '../utils/fileUtils'
 const BIND_ATTRIBUTE_PATTERN = /(?:bind-[a-zA-Z0-9_-]+|if|for-each)=["']([^"']+)["']/g
 const CLICK_ATTRIBUTE_PATTERN = /click=["']([^"']+)["']/g
 
-function provideDefinition(
+export function provideDefinition(
   document: vscode.TextDocument,
   position: vscode.Position,
   _token: vscode.CancellationToken
 ): vscode.ProviderResult<vscode.Definition> {
   const lineText = document.lineAt(position.line).text
 
-  return (
+  const syncResult =
     checkViewModelDefinition(document, position, lineText) ||
     checkBindAttributeDefinitions(document, position, lineText) ||
     checkClickAttributeDefinition(document, position, lineText)
-  )
+
+  return syncResult ?? checkComponentTagDefinition(document, position, lineText)
+}
+
+function findActiveTagMatch(
+  lineText: string,
+  characterPosition: number
+): RegExpMatchArray | undefined {
+  const tagRegex = /<\/?([a-zA-Z0-9-]+)/g
+  const matches = Array.from(lineText.matchAll(tagRegex))
+
+  return matches.find((match) => {
+    const tagName = match[1]
+    const startPos = (match.index ?? 0) + match[0].indexOf(tagName)
+    const endPos = startPos + tagName.length
+    return characterPosition >= startPos && characterPosition <= endPos
+  })
+}
+
+function resolveComponentDefinition(
+  document: vscode.TextDocument,
+  tagName: string
+): vscode.ProviderResult<vscode.Definition> {
+  if (isStandardHtmlTag(tagName) || isPelelaRootTag(tagName)) {
+    return null
+  }
+
+  const currentDir = path.dirname(document.uri.fsPath)
+  const localPelelaPath = path.join(currentDir, `${tagName}.pelela`)
+  if (fs.existsSync(localPelelaPath)) {
+    return new vscode.Location(vscode.Uri.file(localPelelaPath), new vscode.Position(0, 0))
+  }
+
+  return vscode.workspace.findFiles(`**/${tagName}.pelela`).then((uris) => {
+    if (uris && uris.length > 0) {
+      return new vscode.Location(uris[0], new vscode.Position(0, 0))
+    }
+    return null
+  })
+}
+
+function checkComponentTagDefinition(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  lineText: string
+): vscode.ProviderResult<vscode.Definition> {
+  const activeMatch = findActiveTagMatch(lineText, position.character)
+  return activeMatch ? resolveComponentDefinition(document, activeMatch[1]) : null
 }
 
 function checkViewModelDefinition(
@@ -104,6 +154,57 @@ function handleForEachDefinition(
   return null
 }
 
+function buildPropertyPartPositions(
+  fullValue: string,
+  pathParts: string[]
+): Array<{ part: string; partStart: number; partEnd: number; partIndex: number }> {
+  return pathParts.reduce<
+    Array<{
+      part: string
+      partStart: number
+      partEnd: number
+      partIndex: number
+      nextSearchPos: number
+    }>
+  >((acc, rawPart, partIndex) => {
+    const part = rawPart.trim()
+    const searchFrom = acc.length > 0 ? acc[acc.length - 1].nextSearchPos : 0
+    const partStart = fullValue.indexOf(part, searchFrom)
+    const partEnd = partStart + part.length
+    acc.push({ part, partStart, partEnd, partIndex, nextSearchPos: partEnd + 1 })
+    return acc
+  }, [])
+}
+
+function resolvePropertyPartDefinition(
+  document: vscode.TextDocument,
+  fullValue: string,
+  pathParts: string[],
+  cursorOffsetInValue: number,
+  typescriptFilePath: string,
+  forEachInElement: ForEachResult | null
+): vscode.Location | null {
+  const partPositions = buildPropertyPartPositions(fullValue, pathParts)
+
+  const activePart = partPositions.find(
+    ({ partStart, partEnd }) => cursorOffsetInValue >= partStart && cursorOffsetInValue <= partEnd
+  )
+
+  if (!activePart) return null
+
+  if (forEachInElement && activePart.part === forEachInElement.itemName) {
+    return new vscode.Location(
+      document.uri,
+      new vscode.Position(forEachInElement.line, forEachInElement.itemPos)
+    )
+  }
+
+  return findNestedPropertyDefinition(
+    typescriptFilePath,
+    pathParts.slice(0, activePart.partIndex + 1)
+  )
+}
+
 function handlePropertyPathDefinition(
   document: vscode.TextDocument,
   fullValue: string,
@@ -112,28 +213,14 @@ function handlePropertyPathDefinition(
   forEachInElement: ForEachResult | null
 ): vscode.Location | null {
   const pathParts = fullValue.split('.')
-  let currentSearchPos = 0
-
-  for (let partIndex = 0; partIndex < pathParts.length; partIndex++) {
-    const part = pathParts[partIndex].trim()
-    const partStart = fullValue.indexOf(part, currentSearchPos)
-    const partEnd = partStart + part.length
-
-    if (cursorOffsetInValue >= partStart && cursorOffsetInValue <= partEnd) {
-      if (forEachInElement && part === forEachInElement.itemName) {
-        return new vscode.Location(
-          document.uri,
-          new vscode.Position(forEachInElement.line, forEachInElement.itemPos)
-        )
-      }
-
-      return findNestedPropertyDefinition(typescriptFilePath, pathParts.slice(0, partIndex + 1))
-    }
-
-    currentSearchPos = partEnd + 1
-  }
-
-  return null
+  return resolvePropertyPartDefinition(
+    document,
+    fullValue,
+    pathParts,
+    cursorOffsetInValue,
+    typescriptFilePath,
+    forEachInElement
+  )
 }
 
 function checkClickAttributeDefinition(

--- a/tools/pelela-vscode/src/utils/htmlUtils.ts
+++ b/tools/pelela-vscode/src/utils/htmlUtils.ts
@@ -75,6 +75,7 @@ export function getPelelaAttributes() {
     'if',
     'bind-class',
     'bind-style',
+    'const-',
     'click',
     'for-each',
   ]

--- a/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
+++ b/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
@@ -292,7 +292,7 @@
         },
         {
           "name": "meta.attribute.pelela.binding",
-          "match": "\\b(bind-[a-zA-Z0-9_-]+|link-[a-zA-Z0-9_-]+|prop-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
+          "match": "\\b(bind-src|bind-[a-zA-Z0-9_-]+|link-[a-zA-Z0-9_-]+|prop-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
           "captures": {
             "1": {
               "name": "entity.other.attribute-name.pelela.binding"

--- a/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
+++ b/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
@@ -270,8 +270,29 @@
     "binding-attribute": {
       "patterns": [
         {
+          "name": "meta.attribute.pelela.const",
+          "match": "\\b(const-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
+          "captures": {
+            "1": {
+              "name": "entity.other.attribute-name.pelela.binding"
+            },
+            "2": {
+              "name": "punctuation.separator.key-value.html"
+            },
+            "3": {
+              "name": "string.quoted.pelela"
+            },
+            "4": {
+              "name": "string.quoted.pelela"
+            },
+            "5": {
+              "name": "string.quoted.pelela"
+            }
+          }
+        },
+        {
           "name": "meta.attribute.pelela.binding",
-          "match": "\\b(bind-[a-zA-Z0-9_-]+|link-[a-zA-Z0-9_-]+|prop-[a-zA-Z0-9_-]+|const-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
+          "match": "\\b(bind-[a-zA-Z0-9_-]+|link-[a-zA-Z0-9_-]+|prop-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
           "captures": {
             "1": {
               "name": "entity.other.attribute-name.pelela.binding"

--- a/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
+++ b/tools/pelela-vscode/syntaxes/pelela.tmLanguage.json
@@ -271,7 +271,7 @@
       "patterns": [
         {
           "name": "meta.attribute.pelela.binding",
-          "match": "\\b(bind-[a-zA-Z0-9_-]+|link-[a-zA-Z0-9_-]+|prop-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
+          "match": "\\b(bind-[a-zA-Z0-9_-]+|link-[a-zA-Z0-9_-]+|prop-[a-zA-Z0-9_-]+|const-[a-zA-Z0-9_-]+)\\s*(=)\\s*(\"([^\"]*)\"|'([^']*)')",
           "captures": {
             "1": {
               "name": "entity.other.attribute-name.pelela.binding"

--- a/tools/pelela-vscode/test/providers/completionProvider.test.ts
+++ b/tools/pelela-vscode/test/providers/completionProvider.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'node:assert'
+import { describe, it } from 'mocha'
+import * as vscode from 'vscode'
+import { addPelelaAttributeCompletions } from '../../src/providers/completionProvider'
+
+describe('completionProvider - Pelela Attributes', () => {
+  it('should return correct CompletionItem for "const-*" attributes', () => {
+    const items: vscode.CompletionItem[] = []
+    addPelelaAttributeCompletions(items)
+
+    const constItem = items.find((item) => item.label === 'const-')
+    assert.ok(constItem, 'const- completion item should exist')
+
+    // Verify insertText
+    assert.ok(constItem.insertText instanceof vscode.SnippetString)
+    assert.strictEqual(
+      (constItem.insertText as vscode.SnippetString).value,
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: VSCode snippet syntax
+      'const-${1:field-name}="${2:value}"'
+    )
+
+    // Verify detail
+    assert.strictEqual(constItem.detail, 'Pelela: valor constante para un componente')
+
+    // Verify sortText
+    assert.ok(
+      constItem.sortText?.startsWith('!0_'),
+      `sortText should start with !0_, but was ${constItem.sortText}`
+    )
+    assert.strictEqual(constItem.sortText, '!0_const-')
+  })
+})

--- a/tools/pelela-vscode/test/providers/definitionProvider.test.ts
+++ b/tools/pelela-vscode/test/providers/definitionProvider.test.ts
@@ -1,0 +1,117 @@
+import * as assert from 'node:assert'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { after, before, describe, it } from 'mocha'
+import * as vscode from 'vscode'
+import { provideDefinition } from '../../src/providers/definitionProvider'
+
+describe('definitionProvider - Component Tag Navigation', () => {
+  const fixturesDir = path.join(__dirname, '../fixtures')
+  const parentPath = path.join(fixturesDir, 'parent.pelela')
+  const childPath = path.join(fixturesDir, 'child-comp.pelela')
+
+  const fileLines = [
+    '<pelela view-model="Parent">',
+    '  <div>',
+    '    <child-comp prop-value="some"></child-comp>',
+    '    </child-comp>',
+    '    <div class="test"></div>',
+    '</pelela>',
+    '    <workspace-comp></workspace-comp>',
+  ]
+
+  const mockDocument = {
+    uri: vscode.Uri.file(parentPath),
+    lineAt: (line: number) => ({
+      text: fileLines[line],
+    }),
+  } as unknown as vscode.TextDocument
+
+  before(() => {
+    if (!fs.existsSync(fixturesDir)) {
+      fs.mkdirSync(fixturesDir, { recursive: true })
+    }
+    fs.writeFileSync(parentPath, fileLines.join('\n'))
+    fs.writeFileSync(childPath, '<pelela></pelela>')
+  })
+
+  after(() => {
+    if (fs.existsSync(parentPath)) {
+      fs.unlinkSync(parentPath)
+    }
+    if (fs.existsSync(childPath)) {
+      fs.unlinkSync(childPath)
+    }
+  })
+
+  it('should ignore standard HTML and Pelela tags', () => {
+    // Cursor on "<pelela" (line 0, character 3)
+    const posPelela = new vscode.Position(0, 3)
+    const resultPelela = provideDefinition(mockDocument, posPelela, {} as vscode.CancellationToken)
+    assert.strictEqual(resultPelela, null)
+
+    // Cursor on "div" in "  <div>" (line 1, character 5)
+    const posDiv = new vscode.Position(1, 5)
+    const resultDiv = provideDefinition(mockDocument, posDiv, {} as vscode.CancellationToken)
+    assert.strictEqual(resultDiv, null)
+  })
+
+  it('should resolve navigation to local component file in the same directory (opening tag)', () => {
+    // Cursor on "child-comp" in "<child-comp" (line 2, character 10)
+    const posChild = new vscode.Position(2, 10)
+    const location = provideDefinition(
+      mockDocument,
+      posChild,
+      {} as vscode.CancellationToken
+    ) as vscode.Location
+
+    assert.ok(location instanceof vscode.Location)
+    assert.strictEqual(location.uri.fsPath, childPath)
+    assert.strictEqual(location.range.start.line, 0)
+    assert.strictEqual(location.range.start.character, 0)
+  })
+
+  it('should resolve navigation to local component file in the same directory (closing tag)', () => {
+    // Cursor on "child-comp" in "</child-comp>" (line 3, character 10)
+    const posChildClose = new vscode.Position(3, 10)
+    const location = provideDefinition(
+      mockDocument,
+      posChildClose,
+      {} as vscode.CancellationToken
+    ) as vscode.Location
+
+    assert.ok(location instanceof vscode.Location)
+    assert.strictEqual(location.uri.fsPath, childPath)
+    assert.strictEqual(location.range.start.line, 0)
+    assert.strictEqual(location.range.start.character, 0)
+  })
+
+  it('should fallback to workspace search when local file does not exist', async () => {
+    const mockUri = vscode.Uri.file('/some/other/workspace-comp.pelela')
+
+    // Save original findFiles
+    const originalFindFiles = vscode.workspace.findFiles
+
+    try {
+      // Mock workspace.findFiles
+      vscode.workspace.findFiles = (include: vscode.GlobPattern) => {
+        const globStr = typeof include === 'string' ? include : include.pattern
+        assert.ok(globStr.includes('workspace-comp.pelela'))
+        return Promise.resolve([mockUri])
+      }
+
+      // Cursor on "workspace-comp" in "<workspace-comp>" (line 6, character 10)
+      const posWorkspace = new vscode.Position(6, 10)
+      const result = provideDefinition(mockDocument, posWorkspace, {} as vscode.CancellationToken)
+
+      assert.ok(result instanceof Promise || (result && typeof (result as any).then === 'function'))
+      const location = (await result) as vscode.Location
+
+      assert.ok(location instanceof vscode.Location)
+      assert.strictEqual(location.uri.fsPath, mockUri.fsPath)
+    } finally {
+      // Restore original findFiles
+      vscode.workspace.findFiles = originalFindFiles
+    }
+  })
+})

--- a/tools/pelela-vscode/test/providers/definitionProvider.test.ts
+++ b/tools/pelela-vscode/test/providers/definitionProvider.test.ts
@@ -88,6 +88,7 @@ describe('definitionProvider - Component Tag Navigation', () => {
 
   it('should fallback to workspace search when local file does not exist', async () => {
     const mockUri = vscode.Uri.file('/some/other/workspace-comp.pelela')
+    const EXPECTED_GLOB = '**/workspace-comp.pelela'
 
     // Save original findFiles
     const originalFindFiles = vscode.workspace.findFiles
@@ -96,7 +97,7 @@ describe('definitionProvider - Component Tag Navigation', () => {
       // Mock workspace.findFiles
       vscode.workspace.findFiles = (include: vscode.GlobPattern) => {
         const globStr = typeof include === 'string' ? include : include.pattern
-        assert.ok(globStr.includes('workspace-comp.pelela'))
+        assert.strictEqual(globStr, EXPECTED_GLOB)
         return Promise.resolve([mockUri])
       }
 
@@ -104,8 +105,7 @@ describe('definitionProvider - Component Tag Navigation', () => {
       const posWorkspace = new vscode.Position(6, 10)
       const result = provideDefinition(mockDocument, posWorkspace, {} as vscode.CancellationToken)
 
-      assert.ok(result instanceof Promise || (result && typeof (result as any).then === 'function'))
-      const location = (await result) as vscode.Location
+      const location = (await Promise.resolve(result)) as vscode.Location
 
       assert.ok(location instanceof vscode.Location)
       assert.strictEqual(location.uri.fsPath, mockUri.fsPath)

--- a/tools/pelela-vscode/test/utils/htmlUtils.test.ts
+++ b/tools/pelela-vscode/test/utils/htmlUtils.test.ts
@@ -72,13 +72,14 @@ describe('htmlUtils', () => {
       assert.ok(attributes.includes('if'))
       assert.ok(attributes.includes('bind-class'))
       assert.ok(attributes.includes('bind-style'))
+      assert.ok(attributes.includes('const-'))
       assert.ok(attributes.includes('click'))
       assert.ok(attributes.includes('for-each'))
     })
 
-    it('should return exactly 8 attributes', () => {
+    it('should return exactly 9 attributes', () => {
       const attributes = getPelelaAttributes()
-      assert.strictEqual(attributes.length, 8)
+      assert.strictEqual(attributes.length, 9)
     })
   })
 })

--- a/tools/pelela-vscode/test/vscode-stub.ts
+++ b/tools/pelela-vscode/test/vscode-stub.ts
@@ -94,6 +94,7 @@ export const vscodeStub = {
 
   workspace: {
     onDidOpenTextDocument: () => ({ dispose: () => {} }),
+    findFiles: (_glob: string) => Promise.resolve([]),
   },
 
   window: {

--- a/tools/pelela-vscode/tsconfig.json
+++ b/tools/pelela-vscode/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "Bundler",
     "outDir": "dist",
     "sourceMap": true,
-    "rootDir": ".",
     "types": ["node", "vscode", "mocha"]
   },
   "include": ["src", "test"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "types": ["node"],
     "paths": {
-      "pelelajs": ["./packages/core/src/index.ts"]
+      "pelelajs": ["./packages/core/src/index.ts"],
+      "pelelajs/dom": ["./packages/core/src/commons/dom.ts"]
     }
   }
 }


### PR DESCRIPTION
En este PR voy a ir metiendo varios fixes, prioritarios para salir a producción en julio:

- [x] #114 
- [x] #115 
- [x] #113 
- [x] #110 
- [x] #112 
- [x] #117 
- [x] #119 
- [x] #121 
- [x] #122  

## 114 y 115: fixes prop- reactivas y const-

Con las primeras dos pude lograr el ejemplo base para Ruleta con un validador que parametriza el atributo que puede tener errores y lo saca de la apuesta:

<img width="720" height="798" alt="Screen Recording 2026-05-31 at 6 54 19 PM" src="https://github.com/user-attachments/assets/569d8f27-3777-401a-a7a3-a4da3055e4ca" />

## 117: Navegar al componente hijo

Estamos en un .pelela y al hacer F12 sobre <row> vamos al row.pelela:

<img width="720" height="438" alt="Screen Recording 2026-06-01 at 11 47 41 PM" src="https://github.com/user-attachments/assets/80134718-0da0-4f71-abff-5a937ffc1f57" />

## 121: `bind-src` para imágenes y 122: método initialize() en el viewModel que permite disparar fetchs asincrónicos

<img width="550" height="399" alt="Screenshot 2026-06-06 at 12 12 30 AM" src="https://github.com/user-attachments/assets/03a77859-827e-4373-81ae-fc88c350f365" />

- El pokémon se obtiene en forma asincrónica
- La imagen se bindea dinámicamente para cada user

