### PR TITLE
Hotfixes 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,8 @@
   - **Ante la duda, preguntá:** No tomes decisiones de diseño o arquitectura por tu cuenta.
   - **Explicación:** Siempre explicá los cambios importantes siguiendo estas directrices.
 </ai_interaction_protocol>
+
+<lessons_learned>
+
+- **VSCode plugin — tres mecanismos de autocompletado:** Al agregar un nuevo binding (ej. `bind-alt`, `bind-enabled`), hay que actualizar los **3** mecanismos del plugin: `html-custom-data.json` (HTML IntelliSense), `snippets/pelela.json` (snippets), y `src/utils/htmlUtils.ts` → `getPelelaAttributes()` (provider programático). Los planes de bind-alt y bind-enabled omitieron este último, por lo que los bindings aparecían por IntelliSense y snippets pero no en el autocompletado por código.
+</lessons_learned>

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -402,7 +402,7 @@ describe('router', () => {
       defineComponent(
         'Wheel',
         Wheel,
-        '<pelela view-model="Wheel"><Validator></Validator><h1 bind-content="title"></h1></pelela>',
+        '<pelela view-model="Wheel"><validator></validator><h1 bind-content="title"></h1></pelela>',
         { cssUrls: ['/styles/wheel.css'] },
       )
 
@@ -434,7 +434,7 @@ describe('router', () => {
       defineComponent(
         'AppLayout',
         AppLayout,
-        '<pelela view-model="AppLayout"><SomeComponent></SomeComponent><h1 bind-content="title"></h1></pelela>',
+        '<pelela view-model="AppLayout"><some-component></some-component><h1 bind-content="title"></h1></pelela>',
         { cssUrls: ['/styles/app-layout.css'] },
       )
 
@@ -449,6 +449,7 @@ describe('router', () => {
 
       expect(childLink).toBeInstanceOf(HTMLLinkElement)
       expect(parentLink).toBeInstanceOf(HTMLLinkElement)
+      expect(container.querySelector('span')?.innerHTML).toBe('Some')
     })
 
     it('should remove child component CSS when navigating to a different route', () => {
@@ -471,7 +472,7 @@ describe('router', () => {
       defineComponent(
         'Wheel',
         Wheel,
-        '<pelela view-model="Wheel"><Validator></Validator><h1 bind-content="title"></h1></pelela>',
+        '<pelela view-model="Wheel"><validator></validator><h1 bind-content="title"></h1></pelela>',
         { cssUrls: ['/styles/wheel.css'] },
       )
       defineComponent(

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -385,7 +385,7 @@ describe('router', () => {
   })
 
   describe('child component CSS', () => {
-    it('should load CSS from child component with PascalCase single-word tag (e.g. <Validator>)', () => {
+    it('should load CSS from child component with kebab-case single-word tag (e.g. <validator>)', () => {
       class Validator {
         label = 'Validator'
       }
@@ -417,7 +417,7 @@ describe('router', () => {
       expect(wheelLink).toBeInstanceOf(HTMLLinkElement)
     })
 
-    it('should load CSS from child component with PascalCase multi-word tag (e.g. <SomeComponent>)', () => {
+    it('should load CSS from child component with kebab-case multi-word tag (e.g. <some-component>)', () => {
       class SomeComponent {
         label = 'Some'
       }

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -385,36 +385,36 @@ describe('router', () => {
   })
 
   describe('child component CSS', () => {
-    it('should load CSS from child component with PascalCase single-word tag (e.g. <Validador>)', () => {
-      class Validador {
-        label = 'Validador'
+    it('should load CSS from child component with PascalCase single-word tag (e.g. <Validator>)', () => {
+      class Validator {
+        label = 'Validator'
       }
-      class Ruleta {
-        title = 'Ruleta'
+      class Wheel {
+        title = 'Wheel'
       }
 
       defineComponent(
-        'Validador',
-        Validador,
-        '<pelela view-model="Validador"><span bind-content="label"></span></pelela>',
-        { cssUrls: ['/styles/validador.css'] },
+        'Validator',
+        Validator,
+        '<pelela view-model="Validator"><span bind-content="label"></span></pelela>',
+        { cssUrls: ['/styles/validator.css'] },
       )
       defineComponent(
-        'Ruleta',
-        Ruleta,
-        '<pelela view-model="Ruleta"><Validador></Validador><h1 bind-content="title"></h1></pelela>',
-        { cssUrls: ['/styles/ruleta.css'] },
+        'Wheel',
+        Wheel,
+        '<pelela view-model="Wheel"><Validator></Validator><h1 bind-content="title"></h1></pelela>',
+        { cssUrls: ['/styles/wheel.css'] },
       )
 
-      router.start(container, [{ path: '/', component: Ruleta }])
+      router.start(container, [{ path: '/', component: Wheel }])
 
-      const validadorLink = document.querySelector(
-        'link[data-pelela-css-url="/styles/validador.css"]',
+      const validatorLink = document.querySelector(
+        'link[data-pelela-css-url="/styles/validator.css"]',
       )
-      const ruletaLink = document.querySelector('link[data-pelela-css-url="/styles/ruleta.css"]')
+      const wheelLink = document.querySelector('link[data-pelela-css-url="/styles/wheel.css"]')
 
-      expect(validadorLink).toBeInstanceOf(HTMLLinkElement)
-      expect(ruletaLink).toBeInstanceOf(HTMLLinkElement)
+      expect(validatorLink).toBeInstanceOf(HTMLLinkElement)
+      expect(wheelLink).toBeInstanceOf(HTMLLinkElement)
     })
 
     it('should load CSS from child component with PascalCase multi-word tag (e.g. <SomeComponent>)', () => {
@@ -452,27 +452,27 @@ describe('router', () => {
     })
 
     it('should remove child component CSS when navigating to a different route', () => {
-      class Validador {
-        label = 'Validador'
+      class Validator {
+        label = 'Validator'
       }
-      class Ruleta {
-        title = 'Ruleta'
+      class Wheel {
+        title = 'Wheel'
       }
       class Settings {
         version = '1.0'
       }
 
       defineComponent(
-        'Validador',
-        Validador,
-        '<pelela view-model="Validador"><span bind-content="label"></span></pelela>',
-        { cssUrls: ['/styles/validador.css'] },
+        'Validator',
+        Validator,
+        '<pelela view-model="Validator"><span bind-content="label"></span></pelela>',
+        { cssUrls: ['/styles/validator.css'] },
       )
       defineComponent(
-        'Ruleta',
-        Ruleta,
-        '<pelela view-model="Ruleta"><Validador></Validador><h1 bind-content="title"></h1></pelela>',
-        { cssUrls: ['/styles/ruleta.css'] },
+        'Wheel',
+        Wheel,
+        '<pelela view-model="Wheel"><Validator></Validator><h1 bind-content="title"></h1></pelela>',
+        { cssUrls: ['/styles/wheel.css'] },
       )
       defineComponent(
         'Settings',
@@ -482,20 +482,20 @@ describe('router', () => {
       )
 
       router.start(container, [
-        { path: '/', component: Ruleta },
+        { path: '/', component: Wheel },
         { path: '/settings', component: Settings },
       ])
 
-      const childLink = document.querySelector('link[data-pelela-css-url="/styles/validador.css"]')
+      const childLink = document.querySelector('link[data-pelela-css-url="/styles/validator.css"]')
       expect(childLink).toBeInstanceOf(HTMLLinkElement)
 
       router.navigateTo('/settings')
 
       const childLinkAfterNav = document.querySelector(
-        'link[data-pelela-css-url="/styles/validador.css"]',
+        'link[data-pelela-css-url="/styles/validator.css"]',
       )
       const parentLinkAfterNav = document.querySelector(
-        'link[data-pelela-css-url="/styles/ruleta.css"]',
+        'link[data-pelela-css-url="/styles/wheel.css"]',
       )
       expect(childLinkAfterNav).toBeNull()
       expect(parentLinkAfterNav).toBeNull()

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -385,60 +385,94 @@ describe('router', () => {
   })
 
   describe('child component CSS', () => {
-    it('should load CSS from child components used in a route template', () => {
-      class ChildWidget {
-        label = 'Widget'
+    it('should load CSS from child component with PascalCase single-word tag (e.g. <Validador>)', () => {
+      class Validador {
+        label = 'Validador'
       }
-      class Dashboard {
-        title = 'Dashboard'
+      class Ruleta {
+        title = 'Ruleta'
       }
 
       defineComponent(
-        'ChildWidget',
-        ChildWidget,
-        '<pelela view-model="ChildWidget"><span bind-content="label"></span></pelela>',
-        { cssUrls: ['/styles/child-widget.css'] },
+        'Validador',
+        Validador,
+        '<pelela view-model="Validador"><span bind-content="label"></span></pelela>',
+        { cssUrls: ['/styles/validador.css'] },
       )
       defineComponent(
-        'Dashboard',
-        Dashboard,
-        '<pelela view-model="Dashboard"><child-widget></child-widget><h1 bind-content="title"></h1></pelela>',
-        { cssUrls: ['/styles/dashboard.css'] },
+        'Ruleta',
+        Ruleta,
+        '<pelela view-model="Ruleta"><Validador></Validador><h1 bind-content="title"></h1></pelela>',
+        { cssUrls: ['/styles/ruleta.css'] },
       )
 
-      router.start(container, [{ path: '/', component: Dashboard }])
+      router.start(container, [{ path: '/', component: Ruleta }])
+
+      const validadorLink = document.querySelector(
+        'link[data-pelela-css-url="/styles/validador.css"]',
+      )
+      const ruletaLink = document.querySelector('link[data-pelela-css-url="/styles/ruleta.css"]')
+
+      expect(validadorLink).toBeInstanceOf(HTMLLinkElement)
+      expect(ruletaLink).toBeInstanceOf(HTMLLinkElement)
+    })
+
+    it('should load CSS from child component with PascalCase multi-word tag (e.g. <SomeComponent>)', () => {
+      class SomeComponent {
+        label = 'Some'
+      }
+      class AppLayout {
+        title = 'App Layout'
+      }
+
+      defineComponent(
+        'SomeComponent',
+        SomeComponent,
+        '<pelela view-model="SomeComponent"><span bind-content="label"></span></pelela>',
+        { cssUrls: ['/styles/some-component.css'] },
+      )
+      defineComponent(
+        'AppLayout',
+        AppLayout,
+        '<pelela view-model="AppLayout"><SomeComponent></SomeComponent><h1 bind-content="title"></h1></pelela>',
+        { cssUrls: ['/styles/app-layout.css'] },
+      )
+
+      router.start(container, [{ path: '/', component: AppLayout }])
 
       const childLink = document.querySelector(
-        'link[data-pelela-css-url="/styles/child-widget.css"]',
+        'link[data-pelela-css-url="/styles/some-component.css"]',
       )
-      const parentLink = document.querySelector('link[data-pelela-css-url="/styles/dashboard.css"]')
+      const parentLink = document.querySelector(
+        'link[data-pelela-css-url="/styles/app-layout.css"]',
+      )
 
       expect(childLink).toBeInstanceOf(HTMLLinkElement)
       expect(parentLink).toBeInstanceOf(HTMLLinkElement)
     })
 
     it('should remove child component CSS when navigating to a different route', () => {
-      class ChildWidget {
-        label = 'Widget'
+      class Validador {
+        label = 'Validador'
       }
-      class Dashboard {
-        title = 'Dashboard'
+      class Ruleta {
+        title = 'Ruleta'
       }
       class Settings {
         version = '1.0'
       }
 
       defineComponent(
-        'ChildWidget',
-        ChildWidget,
-        '<pelela view-model="ChildWidget"><span bind-content="label"></span></pelela>',
-        { cssUrls: ['/styles/child-widget.css'] },
+        'Validador',
+        Validador,
+        '<pelela view-model="Validador"><span bind-content="label"></span></pelela>',
+        { cssUrls: ['/styles/validador.css'] },
       )
       defineComponent(
-        'Dashboard',
-        Dashboard,
-        '<pelela view-model="Dashboard"><child-widget></child-widget><h1 bind-content="title"></h1></pelela>',
-        { cssUrls: ['/styles/dashboard.css'] },
+        'Ruleta',
+        Ruleta,
+        '<pelela view-model="Ruleta"><Validador></Validador><h1 bind-content="title"></h1></pelela>',
+        { cssUrls: ['/styles/ruleta.css'] },
       )
       defineComponent(
         'Settings',
@@ -448,22 +482,20 @@ describe('router', () => {
       )
 
       router.start(container, [
-        { path: '/', component: Dashboard },
+        { path: '/', component: Ruleta },
         { path: '/settings', component: Settings },
       ])
 
-      const childLink = document.querySelector(
-        'link[data-pelela-css-url="/styles/child-widget.css"]',
-      )
+      const childLink = document.querySelector('link[data-pelela-css-url="/styles/validador.css"]')
       expect(childLink).toBeInstanceOf(HTMLLinkElement)
 
       router.navigateTo('/settings')
 
       const childLinkAfterNav = document.querySelector(
-        'link[data-pelela-css-url="/styles/child-widget.css"]',
+        'link[data-pelela-css-url="/styles/validador.css"]',
       )
       const parentLinkAfterNav = document.querySelector(
-        'link[data-pelela-css-url="/styles/dashboard.css"]',
+        'link[data-pelela-css-url="/styles/ruleta.css"]',
       )
       expect(childLinkAfterNav).toBeNull()
       expect(parentLinkAfterNav).toBeNull()

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -5,6 +5,7 @@ import {
   findExistingStylesheetLink,
   removeStylesheetLinks,
 } from '../commons/cssLoader'
+import { toKebabCase } from '../commons/helpers'
 import { RoutingError } from '../errors/RoutingError'
 import {
   getComponentByTag,
@@ -24,7 +25,11 @@ export function registerCss(cssPath: string): void {
   currentRouteCss.add(cssPath)
 }
 
-function collectChildComponentCssUrls(template: string, visited = new Set<string>()): string[] {
+function collectChildComponentCssUrls(rawTemplate: string, visited = new Set<string>()): string[] {
+  const template = rawTemplate.replace(
+    /<\s*(\w+)/g,
+    (_, tagName: string) => `<${toKebabCase(tagName)}`,
+  )
   const tagRegex = (tag: string) => new RegExp(`<${tag}(?:[\\s>/])`)
 
   return getRegisteredTags()

--- a/tools/pelela-cli/templates/base-template-for-cli/package.json
+++ b/tools/pelela-cli/templates/base-template-for-cli/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "typescript": "5.9.3",
-    "vite": "7.3.2",
+    "vite": "7.3.5",
     "vite-plugin-pelelajs": "latest"
   },
   "engines": {

--- a/tools/pelela-cli/templates/base-template-for-cli/src/vite-env.d.ts
+++ b/tools/pelela-cli/templates/base-template-for-cli/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+declare module 'virtual:pelela-auto-register' {
+  export {}
+}

--- a/tools/pelela-vscode/src/parsers/documentParser.ts
+++ b/tools/pelela-vscode/src/parsers/documentParser.ts
@@ -20,7 +20,7 @@ export function isStartingTag(textBeforeCursor: string): boolean {
 }
 
 export function getCurrentTagName(textBeforeCursor: string): string | null {
-  const tagMatch = /<\s*(\w+)/.exec(textBeforeCursor)
+  const tagMatch = /<\s*([a-zA-Z][\w-]*)[^<>]*$/.exec(textBeforeCursor)
   return tagMatch ? tagMatch[1].toLowerCase() : null
 }
 

--- a/tools/pelela-vscode/src/parsers/documentParser.ts
+++ b/tools/pelela-vscode/src/parsers/documentParser.ts
@@ -19,6 +19,11 @@ export function isStartingTag(textBeforeCursor: string): boolean {
   return /<\w*$/.test(textBeforeCursor)
 }
 
+export function getCurrentTagName(textBeforeCursor: string): string | null {
+  const tagMatch = /<\s*(\w+)/.exec(textBeforeCursor)
+  return tagMatch ? tagMatch[1].toLowerCase() : null
+}
+
 export function getAttributeValueMatch(textBeforeCursor: string): string | null {
   const attributeValueMatch = /=\s*"([^"]*)$/.exec(textBeforeCursor)
   return attributeValueMatch ? attributeValueMatch[1] : null

--- a/tools/pelela-vscode/src/providers/completionProvider.ts
+++ b/tools/pelela-vscode/src/providers/completionProvider.ts
@@ -4,6 +4,7 @@ import {
   findForEachInElement,
   getAttributeValueMatch,
   getCurrentAttributeName,
+  getCurrentTagName,
   isInsideTag,
   isStartingTag,
   parseForEachExpression,
@@ -11,7 +12,7 @@ import {
 } from '../parsers/documentParser'
 import { extractNestedProperties, extractViewModelMembers } from '../parsers/viewModelParser'
 import { findViewModelFile } from '../utils/fileUtils'
-import { getHtmlAttributes, getHtmlElements, getPelelaAttributes } from '../utils/htmlUtils'
+import { getHtmlAttributes, getHtmlElements, getPelelaAttributesForTag } from '../utils/htmlUtils'
 
 const EVENT_ATTRIBUTES = new Set(['click', 'enter'])
 const PELELA_ATTRIBUTE_NAMES = new Set(['click', 'enter', 'if', 'for-each'])
@@ -39,8 +40,9 @@ async function provideCompletionItems(
   if (isStartingTag(textBeforeCursor)) {
     addHtmlElementCompletions(items)
   } else if (isInsideTag(textBeforeCursor)) {
+    const tagName = getCurrentTagName(textBeforeCursor)
     addHtmlAttributeCompletions(items)
-    addPelelaAttributeCompletions(items)
+    addPelelaAttributeCompletions(items, tagName)
   }
 
   return items
@@ -63,8 +65,8 @@ function addHtmlAttributeCompletions(items: vscode.CompletionItem[]): void {
   })
 }
 
-export function addPelelaAttributeCompletions(items: vscode.CompletionItem[]): void {
-  const attrNames = getPelelaAttributes()
+export function addPelelaAttributeCompletions(items: vscode.CompletionItem[], tagName?: string | null): void {
+  const attrNames = getPelelaAttributesForTag(tagName ?? null)
 
   const attributeSnippets: Record<string, { text: string; detail: string }> = {
     'view-model': {

--- a/tools/pelela-vscode/src/providers/completionProvider.ts
+++ b/tools/pelela-vscode/src/providers/completionProvider.ts
@@ -65,7 +65,10 @@ function addHtmlAttributeCompletions(items: vscode.CompletionItem[]): void {
   })
 }
 
-export function addPelelaAttributeCompletions(items: vscode.CompletionItem[], tagName?: string | null): void {
+export function addPelelaAttributeCompletions(
+  items: vscode.CompletionItem[],
+  tagName?: string | null
+): void {
   const attrNames = getPelelaAttributesForTag(tagName ?? null)
 
   const attributeSnippets: Record<string, { text: string; detail: string }> = {

--- a/tools/pelela-vscode/src/utils/htmlUtils.ts
+++ b/tools/pelela-vscode/src/utils/htmlUtils.ts
@@ -70,14 +70,38 @@ export function getHtmlAttributes() {
 export function getPelelaAttributes() {
   return [
     'view-model',
-    'bind-value',
-    'bind-content',
-    'if',
+    'bind-alt',
     'bind-class',
+    'bind-content',
+    'bind-enabled',
+    'bind-src',
     'bind-style',
+    'bind-value',
     'const-',
     'click',
     'enter',
     'for-each',
+    'if',
   ]
+}
+
+const TAG_RESTRICTED_PELELA_ATTRIBUTES: Record<string, string[]> = {
+  'bind-alt': ['img'],
+  'bind-src': ['img'],
+  'bind-enabled': ['input', 'select', 'button', 'textarea', 'optgroup', 'option', 'fieldset'],
+  'bind-value': ['input', 'textarea', 'select'],
+  enter: ['input'],
+  'view-model': ['pelela', 'component'],
+}
+
+export function getPelelaAttributesForTag(tagName: string | null): string[] {
+  const allAttributes = getPelelaAttributes()
+
+  if (!tagName) return allAttributes
+
+  return allAttributes.filter((attr) => {
+    const allowedTags = TAG_RESTRICTED_PELELA_ATTRIBUTES[attr]
+    if (!allowedTags) return true
+    return allowedTags.includes(tagName)
+  })
 }

--- a/tools/pelela-vscode/test/parsers/documentParser.test.ts
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha'
 import {
   getAttributeValueMatch,
   getCurrentAttributeName,
+  getCurrentTagName,
   isInsideTag,
   isStartingTag,
   parseForEachExpression,
@@ -95,6 +96,38 @@ describe('documentParser', () => {
     it('should handle spaces around the equals sign', () => {
       const result = getAttributeValueMatch('bind-value = "test')
       assert.strictEqual(result, 'test')
+    })
+  })
+
+  describe('getCurrentTagName', () => {
+    it('should extract the tag name from an opening tag', () => {
+      const result = getCurrentTagName('<div ')
+      assert.strictEqual(result, 'div')
+    })
+
+    it('should extract the tag name with attributes present', () => {
+      const result = getCurrentTagName('<img src="test" ')
+      assert.strictEqual(result, 'img')
+    })
+
+    it('should extract the tag name from a Pelela root tag', () => {
+      const result = getCurrentTagName('<pelela ')
+      assert.strictEqual(result, 'pelela')
+    })
+
+    it('should extract the tag name from a component tag', () => {
+      const result = getCurrentTagName('<component ')
+      assert.strictEqual(result, 'component')
+    })
+
+    it('should return null for plain text', () => {
+      const result = getCurrentTagName('some text')
+      assert.strictEqual(result, null)
+    })
+
+    it('should handle whitespace after <', () => {
+      const result = getCurrentTagName('< input ')
+      assert.strictEqual(result, 'input')
     })
   })
 

--- a/tools/pelela-vscode/test/parsers/documentParser.test.ts
+++ b/tools/pelela-vscode/test/parsers/documentParser.test.ts
@@ -129,6 +129,11 @@ describe('documentParser', () => {
       const result = getCurrentTagName('< input ')
       assert.strictEqual(result, 'input')
     })
+
+    it('should return the last tag when multiple tags are present', () => {
+      const result = getCurrentTagName('<div><img ')
+      assert.strictEqual(result, 'img')
+    })
   })
 
   describe('parseForEachExpression', () => {

--- a/tools/pelela-vscode/test/utils/htmlUtils.test.ts
+++ b/tools/pelela-vscode/test/utils/htmlUtils.test.ts
@@ -1,6 +1,11 @@
 import * as assert from 'node:assert'
 import { describe, it } from 'mocha'
-import { getHtmlAttributes, getHtmlElements, getPelelaAttributes } from '../../src/utils/htmlUtils'
+import {
+  getHtmlAttributes,
+  getHtmlElements,
+  getPelelaAttributes,
+  getPelelaAttributesForTag,
+} from '../../src/utils/htmlUtils'
 
 describe('htmlUtils', () => {
   describe('getHtmlElements', () => {
@@ -67,20 +72,88 @@ describe('htmlUtils', () => {
       const attributes = getPelelaAttributes()
 
       assert.ok(attributes.includes('view-model'))
-      assert.ok(attributes.includes('bind-value'))
-      assert.ok(attributes.includes('bind-content'))
-      assert.ok(attributes.includes('if'))
+      assert.ok(attributes.includes('bind-alt'))
       assert.ok(attributes.includes('bind-class'))
+      assert.ok(attributes.includes('bind-content'))
+      assert.ok(attributes.includes('bind-enabled'))
+      assert.ok(attributes.includes('bind-src'))
       assert.ok(attributes.includes('bind-style'))
+      assert.ok(attributes.includes('bind-value'))
       assert.ok(attributes.includes('const-'))
       assert.ok(attributes.includes('click'))
       assert.ok(attributes.includes('enter'))
       assert.ok(attributes.includes('for-each'))
+      assert.ok(attributes.includes('if'))
     })
 
-    it('should return exactly 10 attributes', () => {
+    it('should return exactly 13 attributes', () => {
       const attributes = getPelelaAttributes()
-      assert.strictEqual(attributes.length, 10)
+      assert.strictEqual(attributes.length, 13)
+    })
+  })
+
+  describe('getPelelaAttributesForTag', () => {
+    it('should return all attributes for a tag without restrictions', () => {
+      const attributes = getPelelaAttributesForTag('div')
+
+      assert.ok(attributes.includes('bind-class'))
+      assert.ok(attributes.includes('bind-content'))
+      assert.ok(attributes.includes('click'))
+      assert.ok(attributes.includes('if'))
+    })
+
+    it('should include bind-alt for img tags', () => {
+      const attributes = getPelelaAttributesForTag('img')
+
+      assert.ok(attributes.includes('bind-alt'))
+      assert.ok(attributes.includes('bind-src'))
+    })
+
+    it('should exclude bind-alt for non-img tags', () => {
+      const attributes = getPelelaAttributesForTag('input')
+
+      assert.ok(!attributes.includes('bind-alt'))
+      assert.ok(!attributes.includes('bind-src'))
+    })
+
+    it('should include bind-enabled for form control tags', () => {
+      const attributes = getPelelaAttributesForTag('input')
+
+      assert.ok(attributes.includes('bind-enabled'))
+    })
+
+    it('should exclude bind-enabled for non-form tags', () => {
+      const attributes = getPelelaAttributesForTag('div')
+
+      assert.ok(!attributes.includes('bind-enabled'))
+    })
+
+    it('should include enter only for input tags', () => {
+      const inputAttrs = getPelelaAttributesForTag('input')
+      const divAttrs = getPelelaAttributesForTag('div')
+
+      assert.ok(inputAttrs.includes('enter'))
+      assert.ok(!divAttrs.includes('enter'))
+    })
+
+    it('should include view-model only for pelela and component tags', () => {
+      const pelelaAttrs = getPelelaAttributesForTag('pelela')
+      const componentAttrs = getPelelaAttributesForTag('component')
+      const divAttrs = getPelelaAttributesForTag('div')
+
+      assert.ok(pelelaAttrs.includes('view-model'))
+      assert.ok(componentAttrs.includes('view-model'))
+      assert.ok(!divAttrs.includes('view-model'))
+    })
+
+    it('should return all attributes when tagName is null', () => {
+      const attributes = getPelelaAttributesForTag(null)
+
+      assert.ok(attributes.includes('bind-alt'))
+      assert.ok(attributes.includes('bind-enabled'))
+      assert.ok(attributes.includes('enter'))
+      assert.ok(attributes.includes('view-model'))
+      assert.strictEqual(attributes.length, 13)
     })
   })
 })

--- a/tools/pelela-vscode/tsconfig.json
+++ b/tools/pelela-vscode/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "outDir": "dist",
+    "rootDir": ".",
     "sourceMap": true,
     "types": ["node", "vscode", "mocha"]
   },

--- a/tools/pelela-vscode/tsconfig.json
+++ b/tools/pelela-vscode/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "outDir": "dist",
-    "rootDir": ".",
     "sourceMap": true,
     "types": ["node", "vscode", "mocha"]
   },


### PR DESCRIPTION
Probando una última vez llegué a encontrar dos temas:

- [x] el que más me molesta, la estrategia de carga de css para componentes hijos estaba mal, buscaba componentes con archivos en camel case y eso no funciona. Lo arreglé haciendo TDD.
- [x] al usar el autocompletado no me aparecía `bind-alt` en un tag `<img>` para el plugin de vscode, con lo que descubrí que el autocompletado estaba mal también
- [x] actualicé la versión de vite del pelela-cli a 7.3.5 que tiene una vulnerabilidad low en Windows (despreciable) y de paso agrego un archivo para que no falle si abren el `main.ts` porque falta el auto-register de Pelela y styles.css

Después había un errorcito del tsconfig.