### PR TITLE
Improve kebab-case validation for component tags

### DIFF
--- a/packages/core/src/bindings/bindComponent.ts
+++ b/packages/core/src/bindings/bindComponent.ts
@@ -116,7 +116,7 @@ function validateTags(root: HTMLElement, registeredTags: string[]): void {
   allElements.filter(isPotentialComponent).forEach((element) => {
     const tagName = element.tagName.toLowerCase()
     if (!registeredTags.includes(tagName)) {
-      throw new UnknownComponentError(tagName, element)
+      throw new UnknownComponentError(tagName, element, registeredTags)
     }
   })
 }

--- a/packages/core/src/bindings/bindComponentValidation.test.ts
+++ b/packages/core/src/bindings/bindComponentValidation.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { initializeI18n } from '../commons/i18n'
+import { initializeI18n, t } from '../commons/i18n'
 import { UnknownComponentPropertyError } from '../errors'
 import { createReactiveViewModel } from '../reactivity/reactiveProxy'
 import { clearComponentRegistry, defineComponent } from '../registry/componentRegistry'
@@ -27,6 +27,22 @@ describe('bindComponent validation', () => {
 
     expect(() => setupComponentBindings(container, vm)).toThrow(
       /Unknown component: <my-unknown-comp>/,
+    )
+  })
+
+  it('should suggest the registered kebab-case tag when the DOM contains the collapsed tag', () => {
+    class PersonRow {}
+    defineComponent('PersonRow', PersonRow, '<component view-model="PersonRow"></component>')
+
+    container.innerHTML =
+      '<personrow prop-person="person" prop-index="index" prop-selected-index="selectedIndex"></personrow>'
+    const vm = createReactiveViewModel({}, () => {})
+
+    expect(() => setupComponentBindings(container, vm)).toThrow(
+      t('errors.compiler.invalidComponentTagCase', {
+        tag: 'personrow',
+        suggestedTag: 'person-row',
+      }),
     )
   })
 

--- a/packages/core/src/bindings/bindComponentValidation.test.ts
+++ b/packages/core/src/bindings/bindComponentValidation.test.ts
@@ -46,6 +46,25 @@ describe('bindComponent validation', () => {
     )
   })
 
+  it('should not suggest a kebab-case tag when the collapsed component tag is ambiguous', () => {
+    const ambiguousTagName = 'personrowx'
+    const ambiguousSnippet = `<${ambiguousTagName}></${ambiguousTagName}>`
+    class PersonRowX {}
+    class PersonrowX {}
+    defineComponent('PersonRowX', PersonRowX, '<component view-model="PersonRowX"></component>')
+    defineComponent('PersonrowX', PersonrowX, '<component view-model="PersonrowX"></component>')
+
+    container.innerHTML = ambiguousSnippet
+    const vm = createReactiveViewModel({}, () => {})
+
+    expect(() => setupComponentBindings(container, vm)).toThrow(
+      t('errors.compiler.unknownComponent', {
+        tagName: ambiguousTagName,
+        snippet: ambiguousSnippet,
+      }),
+    )
+  })
+
   it('should NOT throw for standard HTML tags', () => {
     container.innerHTML = '<div><span></span><p></p><section></section></div>'
     const vm = createReactiveViewModel({}, () => {})

--- a/packages/core/src/commons/helpers.test.ts
+++ b/packages/core/src/commons/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   extractElementSnippet,
   filterOwnElements,
   findAllElements,
+  findUniqueCollapsedTag,
   isObject,
   isPropertyOrNestedPath,
   isValidIdentifier,
@@ -191,6 +192,20 @@ describe('helpers', () => {
 
     it('should handle multiple words', () => {
       expect(toKebabCase('myLongComponentName')).toBe('my-long-component-name')
+    })
+  })
+
+  describe('findUniqueCollapsedTag', () => {
+    it('should return the matching tag when the collapsed match is unique', () => {
+      expect(findUniqueCollapsedTag('personrow', ['person-row'])).toBe('person-row')
+    })
+
+    it('should return undefined when there are no collapsed matches', () => {
+      expect(findUniqueCollapsedTag('personrow', ['counter'])).toBeUndefined()
+    })
+
+    it('should return undefined when the collapsed match is ambiguous', () => {
+      expect(findUniqueCollapsedTag('personrow', ['person-row', 'personr-ow'])).toBeUndefined()
     })
   })
 

--- a/packages/core/src/commons/helpers.ts
+++ b/packages/core/src/commons/helpers.ts
@@ -66,6 +66,17 @@ export function toKebabCase(str: string): string {
   return str.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
 }
 
+export function findUniqueCollapsedTag(
+  tagName: string,
+  candidateTags: string[],
+): string | undefined {
+  const matchingTags = candidateTags.filter(
+    (candidateTag) => candidateTag.replace(/-/g, '') === tagName,
+  )
+
+  return matchingTags.length === 1 ? matchingTags[0] : undefined
+}
+
 export function isPropertyOrNestedPath(property: string | symbol, root: string): boolean {
   return typeof property === 'string' && (property === root || property.startsWith(`${root}.`))
 }

--- a/packages/core/src/commons/locales/en.ts
+++ b/packages/core/src/commons/locales/en.ts
@@ -59,6 +59,8 @@ const errors = {
       'Pelela template "{{filePath}}" contains unsupported "{{ expression }}" syntax. PelelaJS does not allow mustache-style interpolation. Use binding directives like bind-content="value" instead.',
     foreignPropertyBinding:
       'Pelela template "{{filePath}}" contains Angular-like property binding ("[property]=value"). PelelaJS does not support JS constructs in HTML. Pass static attributes and delegate logic to the ViewModel.',
+    invalidComponentTagCase:
+      'Component tag <{{tag}}> must use kebab-case in .pelela files because HTML lowercases tag names. Use <{{suggestedTag}}> instead.',
     invalidComponentAttribute:
       'Component <{{tag}}>: attribute "{{attr}}" must use "prop-" (one-way), "link-" (two-way) or "const-" prefix',
     onlyForImg: '{{binding}} can only be used on <img> elements, not on <{{tag}}>.',

--- a/packages/core/src/commons/locales/en.ts
+++ b/packages/core/src/commons/locales/en.ts
@@ -60,7 +60,7 @@ const errors = {
     foreignPropertyBinding:
       'Pelela template "{{filePath}}" contains Angular-like property binding ("[property]=value"). PelelaJS does not support JS constructs in HTML. Pass static attributes and delegate logic to the ViewModel.',
     invalidComponentTagCase:
-      'Component tag <{{tag}}> must use kebab-case in .pelela files because HTML lowercases tag names. Use <{{suggestedTag}}> instead.',
+      'Component tag <{{tag}}> must use kebab-case in .pelela files. Use <{{suggestedTag}}> instead.',
     invalidComponentAttribute:
       'Component <{{tag}}>: attribute "{{attr}}" must use "prop-" (one-way), "link-" (two-way) or "const-" prefix',
     onlyForImg: '{{binding}} can only be used on <img> elements, not on <{{tag}}>.',

--- a/packages/core/src/commons/locales/es.ts
+++ b/packages/core/src/commons/locales/es.ts
@@ -64,7 +64,7 @@ const errors = {
     foreignPropertyBinding:
       'Pelela template "{{filePath}}" contiene property binding tipo Angular ("[property]=value"). En PelelaJS no se admiten construcciones JS en HTML. Pase atributos estáticos y delegue lógica al ViewModel.',
     invalidComponentTagCase:
-      'El tag de componente <{{tag}}> debe usar kebab-case en archivos .pelela porque HTML convierte los tags a minúsculas. Usá <{{suggestedTag}}> en su lugar.',
+      'El tag de componente <{{tag}}> debe usar kebab-case en archivos .pelela. Usá <{{suggestedTag}}> en su lugar.',
     invalidComponentAttribute:
       'Componente <{{tag}}>: el atributo "{{attr}}" debe usar el prefijo "prop-" (one-way), "link-" (two-way) o "const-"',
     onlyForImg: '{{binding}} solo puede usarse en elementos <img>, no en <{{tag}}>.',

--- a/packages/core/src/commons/locales/es.ts
+++ b/packages/core/src/commons/locales/es.ts
@@ -63,6 +63,8 @@ const errors = {
       'Pelela template "{{filePath}}" contiene sintaxis "{{ expression }}" no soportada. En PelelaJS no se permite interpolación estilo mustache. Usá directivas de binding como bind-content="valor" en su lugar.',
     foreignPropertyBinding:
       'Pelela template "{{filePath}}" contiene property binding tipo Angular ("[property]=value"). En PelelaJS no se admiten construcciones JS en HTML. Pase atributos estáticos y delegue lógica al ViewModel.',
+    invalidComponentTagCase:
+      'El tag de componente <{{tag}}> debe usar kebab-case en archivos .pelela porque HTML convierte los tags a minúsculas. Usá <{{suggestedTag}}> en su lugar.',
     invalidComponentAttribute:
       'Componente <{{tag}}>: el atributo "{{attr}}" debe usar el prefijo "prop-" (one-way), "link-" (two-way) o "const-"',
     onlyForImg: '{{binding}} solo puede usarse en elementos <img>, no en <{{tag}}>.',

--- a/packages/core/src/commons/locales/translationSchema.ts
+++ b/packages/core/src/commons/locales/translationSchema.ts
@@ -44,6 +44,7 @@ type ErrorTranslations = {
     unbalancedTags: string
     foreignInterpolation: string
     foreignPropertyBinding: string
+    invalidComponentTagCase: string
     invalidComponentAttribute: string
     onlyForImg: string
     enterOnlyForInput: string

--- a/packages/core/src/errors/UnknownComponentError.ts
+++ b/packages/core/src/errors/UnknownComponentError.ts
@@ -1,18 +1,10 @@
-import { extractElementSnippet } from '../commons/helpers'
+import { extractElementSnippet, findUniqueCollapsedTag } from '../commons/helpers'
 import { t } from '../commons/i18n'
 import { PelelaError } from './PelelaError'
 
-function findKebabCaseSuggestion(tagName: string, registeredTags: string[]): string | undefined {
-  const matchingTags = registeredTags.filter(
-    (registeredTag) => registeredTag.replace(/-/g, '') === tagName,
-  )
-
-  return matchingTags.length === 1 ? matchingTags[0] : undefined
-}
-
 export class UnknownComponentError extends PelelaError {
   constructor(tagName: string, element: HTMLElement, registeredTags: string[] = []) {
-    const suggestedTag = findKebabCaseSuggestion(tagName, registeredTags)
+    const suggestedTag = findUniqueCollapsedTag(tagName, registeredTags)
 
     super(
       suggestedTag

--- a/packages/core/src/errors/UnknownComponentError.ts
+++ b/packages/core/src/errors/UnknownComponentError.ts
@@ -3,7 +3,11 @@ import { t } from '../commons/i18n'
 import { PelelaError } from './PelelaError'
 
 function findKebabCaseSuggestion(tagName: string, registeredTags: string[]): string | undefined {
-  return registeredTags.find((registeredTag) => registeredTag.replace(/-/g, '') === tagName)
+  const matchingTags = registeredTags.filter(
+    (registeredTag) => registeredTag.replace(/-/g, '') === tagName,
+  )
+
+  return matchingTags.length === 1 ? matchingTags[0] : undefined
 }
 
 export class UnknownComponentError extends PelelaError {

--- a/packages/core/src/errors/UnknownComponentError.ts
+++ b/packages/core/src/errors/UnknownComponentError.ts
@@ -2,13 +2,24 @@ import { extractElementSnippet } from '../commons/helpers'
 import { t } from '../commons/i18n'
 import { PelelaError } from './PelelaError'
 
+function findKebabCaseSuggestion(tagName: string, registeredTags: string[]): string | undefined {
+  return registeredTags.find((registeredTag) => registeredTag.replace(/-/g, '') === tagName)
+}
+
 export class UnknownComponentError extends PelelaError {
-  constructor(tagName: string, element: HTMLElement) {
+  constructor(tagName: string, element: HTMLElement, registeredTags: string[] = []) {
+    const suggestedTag = findKebabCaseSuggestion(tagName, registeredTags)
+
     super(
-      t('errors.compiler.unknownComponent', {
-        tagName,
-        snippet: extractElementSnippet(element),
-      }),
+      suggestedTag
+        ? t('errors.compiler.invalidComponentTagCase', {
+            tag: tagName,
+            suggestedTag,
+          })
+        : t('errors.compiler.unknownComponent', {
+            tagName,
+            snippet: extractElementSnippet(element),
+          }),
     )
     this.name = 'UnknownComponentError'
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export {
   LINK_PREFIX,
   PROP_PREFIX,
 } from './commons/dom'
+export { findUniqueCollapsedTag } from './commons/helpers'
 export { initializeI18n, t } from './commons/i18n'
 export type { BindingKind, EventType, RegistrationType, RoutingErrorType } from './errors/index'
 export {

--- a/packages/vite-plugin-pelelajs/src/index.test.ts
+++ b/packages/vite-plugin-pelelajs/src/index.test.ts
@@ -530,12 +530,7 @@ describe('pelelajsPlugin', () => {
 
       handler.call({ error: errorFn } as never, pelelaPath, {} as never)
 
-      expect(errors).not.toContain(
-        t('errors.compiler.invalidComponentTagCase', {
-          tag: 'counter',
-          suggestedTag: 'counter',
-        }),
-      )
+      expect(errors).toEqual([])
     })
 
     it('reports error when component tag uses PascalCase', () => {
@@ -573,9 +568,7 @@ describe('pelelajsPlugin', () => {
 
       handler.call({ error: errorFn } as never, pelelaPath, {} as never)
 
-      expect(errors).not.toContain(
-        t('errors.compiler.invalidComponentTagCase', { tag: 'DIV', suggestedTag: 'div' }),
-      )
+      expect(errors).toEqual([])
     })
 
     it('accepts prop-* prefix on component attributes', () => {

--- a/packages/vite-plugin-pelelajs/src/index.test.ts
+++ b/packages/vite-plugin-pelelajs/src/index.test.ts
@@ -436,6 +436,148 @@ describe('pelelajsPlugin', () => {
       )
     })
 
+    it('reports error when component tag uses camelCase', () => {
+      const pelelaPath = path.join(tempDir, 'camel-case-component.pelela')
+      fs.writeFileSync(
+        pelelaPath,
+        '<pelela view-model="Home"><myComponent prop-value="x"></myComponent></pelela>',
+      )
+
+      const errors: string[] = []
+      const errorFn = (msg: string | Error) => errors.push(String(msg))
+
+      const plugin = pelelajsPlugin()
+      const handler = getHandler(plugin.load!)
+
+      handler.call({ error: errorFn } as never, pelelaPath, {} as never)
+
+      expect(errors).toContain(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: 'myComponent',
+          suggestedTag: 'my-component',
+        }),
+      )
+    })
+
+    it('reports error when component tag uses camelCase in pelela request with query params', () => {
+      const pelelaPath = path.join(tempDir, 'camel-case-component-query.pelela')
+      fs.writeFileSync(
+        pelelaPath,
+        '<pelela view-model="Home"><myComponent prop-value="x"></myComponent></pelela>',
+      )
+
+      const errors: string[] = []
+      const errorFn = (msg: string | Error) => errors.push(String(msg))
+
+      const plugin = pelelajsPlugin()
+      const handler = getHandler(plugin.load!)
+
+      handler.call({ error: errorFn } as never, `${pelelaPath}?import&t=123`, {} as never)
+
+      expect(errors).toContain(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: 'myComponent',
+          suggestedTag: 'my-component',
+        }),
+      )
+    })
+
+    it('reports error when component tag collapsed a registered kebab-case component', () => {
+      fs.writeFileSync(path.join(tempDir, 'person-row.ts'), 'export class PersonRow {}')
+      fs.writeFileSync(
+        path.join(tempDir, 'person-row.pelela'),
+        '<pelela view-model="PersonRow"></pelela>',
+      )
+      const pelelaPath = path.join(tempDir, 'collapsed-component.pelela')
+      fs.writeFileSync(
+        pelelaPath,
+        '<pelela view-model="Home"><personrow prop-value="x"></personrow></pelela>',
+      )
+
+      const errors: string[] = []
+      const errorFn = (msg: string | Error) => errors.push(String(msg))
+
+      const plugin = pelelajsPlugin()
+      const handler = getHandler(plugin.load!)
+
+      handler.call({ error: errorFn } as never, pelelaPath, {} as never)
+
+      expect(errors).toContain(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: 'personrow',
+          suggestedTag: 'person-row',
+        }),
+      )
+    })
+
+    it('accepts registered single-word component tags', () => {
+      fs.writeFileSync(path.join(tempDir, 'counter.ts'), 'export class Counter {}')
+      fs.writeFileSync(
+        path.join(tempDir, 'counter.pelela'),
+        '<pelela view-model="Counter"></pelela>',
+      )
+      const pelelaPath = path.join(tempDir, 'single-word-component.pelela')
+      fs.writeFileSync(
+        pelelaPath,
+        '<pelela view-model="Home"><counter prop-value="x"></counter></pelela>',
+      )
+
+      const errors: string[] = []
+      const errorFn = (msg: string | Error) => errors.push(String(msg))
+
+      const plugin = pelelajsPlugin()
+      const handler = getHandler(plugin.load!)
+
+      handler.call({ error: errorFn } as never, pelelaPath, {} as never)
+
+      expect(errors).not.toContain(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: 'counter',
+          suggestedTag: 'counter',
+        }),
+      )
+    })
+
+    it('reports error when component tag uses PascalCase', () => {
+      const pelelaPath = path.join(tempDir, 'pascal-case-component.pelela')
+      fs.writeFileSync(
+        pelelaPath,
+        '<pelela view-model="Home"><MyComponent prop-value="x"></MyComponent></pelela>',
+      )
+
+      const errors: string[] = []
+      const errorFn = (msg: string | Error) => errors.push(String(msg))
+
+      const plugin = pelelajsPlugin()
+      const handler = getHandler(plugin.load!)
+
+      handler.call({ error: errorFn } as never, pelelaPath, {} as never)
+
+      expect(errors).toContain(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: 'MyComponent',
+          suggestedTag: 'my-component',
+        }),
+      )
+    })
+
+    it('accepts uppercase standard HTML tags', () => {
+      const pelelaPath = path.join(tempDir, 'uppercase-html.pelela')
+      fs.writeFileSync(pelelaPath, '<pelela view-model="Home"><DIV></DIV></pelela>')
+
+      const errors: string[] = []
+      const errorFn = (msg: string | Error) => errors.push(String(msg))
+
+      const plugin = pelelajsPlugin()
+      const handler = getHandler(plugin.load!)
+
+      handler.call({ error: errorFn } as never, pelelaPath, {} as never)
+
+      expect(errors).not.toContain(
+        t('errors.compiler.invalidComponentTagCase', { tag: 'DIV', suggestedTag: 'div' }),
+      )
+    })
+
     it('accepts prop-* prefix on component attributes', () => {
       const pelelaPath = path.join(tempDir, 'valid-props.pelela')
       fs.writeFileSync(

--- a/packages/vite-plugin-pelelajs/src/index.ts
+++ b/packages/vite-plugin-pelelajs/src/index.ts
@@ -1,15 +1,17 @@
 import * as fs from 'node:fs'
 import path from 'node:path'
-import {
-  initializeI18n,
-  isPelelaRootTag,
-  isStandardHtmlTag,
-  isValidComponentAttribute,
-  LINK_PREFIX,
-  t,
-} from 'pelelajs'
+import { initializeI18n } from 'pelelajs'
 
 import type { Plugin } from 'vite'
+import {
+  componentTagToKebabCase,
+  getPelelaFilePath,
+  validatePelelaSource,
+} from './templateValidation'
+
+export { extractLinkAttributeMatches } from './templateValidation'
+
+const PLUGIN_NAME = 'vite-plugin-pelelajs'
 
 interface ComponentFileMetadata {
   name: string
@@ -30,215 +32,6 @@ function getCssImport(pelelaFilePath: string): string {
     return `export const __pelelaCssUrls = [new URL("./${cssBase}", import.meta.url).href];\n`
   }
   return 'export const __pelelaCssUrls = [];\n'
-}
-
-const TAG_PATTERN = /<([\w-]+)([^>]*)>/g
-const LINK_ATTRIBUTE_PATTERN = new RegExp(`\\b(${LINK_PREFIX}[a-zA-Z0-9_-]+)\\s*=`, 'g')
-
-function extractAttributes(
-  sourceCode: string,
-  attrPattern: RegExp,
-): Array<{ tagName: string; attributeName: string }> {
-  return Array.from(sourceCode.matchAll(TAG_PATTERN)).flatMap((tagMatch) => {
-    const tagName = tagMatch[1].toLowerCase()
-    const attributesSegment = tagMatch[2]
-    return Array.from(attributesSegment.matchAll(attrPattern), (attrMatch) => ({
-      tagName,
-      attributeName: attrMatch[1],
-    }))
-  })
-}
-
-export function extractLinkAttributeMatches(
-  sourceCode: string,
-): Array<{ tagName: string; attributeName: string }> {
-  return extractAttributes(sourceCode, LINK_ATTRIBUTE_PATTERN)
-}
-
-const ATTRIBUTE_PAIR_PATTERN = /([a-zA-Z0-9_-]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?/g
-
-function extractAttributeNames(attributesSegment: string): string[] {
-  return Array.from(attributesSegment.matchAll(ATTRIBUTE_PAIR_PATTERN), (match) => match[1])
-}
-
-function extractComponentAttributeMatches(
-  sourceCode: string,
-): Array<{ tagName: string; attributeName: string }> {
-  return Array.from(sourceCode.matchAll(TAG_PATTERN)).flatMap((tagMatch) =>
-    extractAttributeNames(tagMatch[2]).map((attributeName) => ({
-      tagName: tagMatch[1].toLowerCase(),
-      attributeName,
-    })),
-  )
-}
-
-function validateComponentAttributes(sourceCode: string, errorFn: (message: string) => void): void {
-  const componentMatches = extractComponentAttributeMatches(sourceCode)
-
-  const invalidMatches = componentMatches.filter(
-    (match) =>
-      !isPelelaRootTag(match.tagName) &&
-      !isStandardHtmlTag(match.tagName) &&
-      !isValidComponentAttribute(match.attributeName),
-  )
-
-  invalidMatches.forEach((match) => {
-    errorFn(
-      t('errors.compiler.invalidComponentAttribute', {
-        tag: match.tagName,
-        attr: match.attributeName,
-      }),
-    )
-  })
-}
-
-function validateNoForbiddenHtmlAttributes(
-  sourceCode: string,
-  filePath: string,
-  errorFn: (message: string) => void,
-): void {
-  const linkMatches = extractLinkAttributeMatches(sourceCode)
-
-  const invalidMatches = linkMatches.filter(
-    (match) => !isPelelaRootTag(match.tagName) && isStandardHtmlTag(match.tagName),
-  )
-
-  invalidMatches.forEach((match) => {
-    errorFn(
-      t('errors.compiler.forbiddenRootAttribute', {
-        filePath,
-        tagName: match.tagName,
-        attr: match.attributeName,
-        snippet: `<${match.tagName} ${match.attributeName}="...">`,
-      }),
-    )
-  })
-}
-
-function validatePelelaStructure(
-  sourceCode: string,
-  filePath: string,
-  errorFn: (message: string) => void,
-): void {
-  const openTags = sourceCode.match(/<(?:pelela|component)\b[^>]*>/gi) || []
-  const closeTags = sourceCode.match(/<\/(?:pelela|component)>/gi) || []
-
-  if (openTags.length === 0) {
-    errorFn(t('errors.compiler.missingRoot', { filePath }))
-  }
-
-  if (openTags.length > 1) {
-    errorFn(t('errors.compiler.multipleRoots', { filePath, count: openTags.length }))
-  }
-
-  if (closeTags.length === 0) {
-    errorFn(t('errors.compiler.missingClosingTag', { filePath }))
-  }
-
-  if (closeTags.length !== openTags.length) {
-    errorFn(t('errors.compiler.unbalancedTags', { filePath }))
-  }
-}
-
-const IMG_ONLY_BINDINGS = ['bind-src', 'bind-alt'] as const
-const INPUT_ONLY_EVENTS = ['enter'] as const
-
-function validateBindingElementRestrictions(
-  sourceCode: string,
-  errorFn: (message: string) => void,
-): void {
-  for (const binding of IMG_ONLY_BINDINGS) {
-    const pattern = new RegExp(
-      `<([a-zA-Z][a-zA-Z0-9]*)\\s[^>]*(?<![a-zA-Z0-9_-])${binding}\\s*=`,
-      'gi',
-    )
-    const matches = sourceCode.matchAll(pattern)
-    for (const match of matches) {
-      const tagName = match[1].toLowerCase()
-      if (tagName !== 'img') {
-        errorFn(t('errors.compiler.onlyForImg', { binding, tag: tagName }))
-      }
-    }
-  }
-}
-
-function validateInputOnlyEvents(sourceCode: string, errorFn: (message: string) => void): void {
-  for (const eventName of INPUT_ONLY_EVENTS) {
-    const pattern = new RegExp(
-      `<([a-zA-Z][a-zA-Z0-9]*)\\s[^>]*(?<![a-zA-Z0-9_-])${eventName}\\s*=`,
-      'gi',
-    )
-    const matches = sourceCode.matchAll(pattern)
-    for (const match of matches) {
-      const tagName = match[1].toLowerCase()
-      if (tagName !== 'input') {
-        errorFn(t('errors.compiler.enterOnlyForInput', { tag: tagName }))
-      }
-    }
-  }
-}
-
-function validateNoForeignSyntax(
-  sourceCode: string,
-  filePath: string,
-  errorFn: (message: string) => void,
-): void {
-  if (/\{\{.*?\}\}/.test(sourceCode)) {
-    errorFn(t('errors.compiler.foreignInterpolation', { filePath }))
-  }
-
-  if (/<[^>]+ \[[^\]]+\]\s*=.*/.test(sourceCode)) {
-    errorFn(t('errors.compiler.foreignPropertyBinding', { filePath }))
-  }
-}
-
-function validateNoForbiddenRootAttributes(
-  sourceCode: string,
-  filePath: string,
-  errorFn: (message: string) => void,
-): void {
-  const rootTagMatch = sourceCode.match(/<(pelela|component)\b([^>]*)>/i)
-  if (!rootTagMatch) return
-
-  const attributes = rootTagMatch[2]
-  const forbiddenPatterns = [
-    new RegExp(`\\b${LINK_PREFIX}[a-zA-Z0-9_-]+`),
-    /\bbind-[a-zA-Z0-9_-]+/,
-    /\bif\s*=/,
-    /\bfor-each\s*=/,
-    /\bclick\s*=/,
-    /\benter\s*=/,
-  ]
-
-  const foundPattern = forbiddenPatterns.find((pattern) => pattern.test(attributes))
-  const foundAttribute = attributes.match(foundPattern ?? '')?.[0]
-
-  if (foundPattern) {
-    errorFn(
-      t('errors.compiler.forbiddenRootAttribute', {
-        filePath,
-        tagName: rootTagMatch[1],
-        attr: foundAttribute,
-        snippet: `<${rootTagMatch[1]} ${foundAttribute}="...">`,
-      }),
-    )
-  }
-}
-
-function extractViewModelName(
-  sourceCode: string,
-  filePath: string,
-  errorFn: (message: string) => void,
-): string {
-  const viewModelMatch = sourceCode.match(/<(?:pelela|component)[^>]*view-model\s*=\s*"([^"]+)"/i)
-  const viewModelName = viewModelMatch ? viewModelMatch[1] : null
-
-  if (!viewModelName) {
-    errorFn(t('errors.compiler.missingViewModel', { filePath }))
-    return ''
-  }
-
-  return viewModelName
 }
 
 function generateModuleCode(
@@ -338,11 +131,17 @@ ${registrations}
 `
 }
 
+function getKnownComponentTags(pelelaFilePath: string): string[] {
+  return findComponentFiles(path.dirname(pelelaFilePath)).map((component) =>
+    componentTagToKebabCase(component.viewModelName),
+  )
+}
+
 export function pelelajsPlugin(): Plugin {
   initializeI18n()
 
   return {
-    name: 'vite-plugin-pelelajs',
+    name: PLUGIN_NAME,
     enforce: 'pre',
 
     resolveId(id) {
@@ -364,22 +163,20 @@ export function pelelajsPlugin(): Plugin {
         return generateAutoRegistrationCode(components)
       }
 
-      if (!filePath.endsWith('.pelela')) {
+      const pelelaFilePath = getPelelaFilePath(filePath)
+      if (!pelelaFilePath) {
         return null
       }
 
-      const sourceCode = fs.readFileSync(filePath, 'utf-8')
-      const cssImport = getCssImport(filePath)
+      const sourceCode = fs.readFileSync(pelelaFilePath, 'utf-8')
+      const cssImport = getCssImport(pelelaFilePath)
 
-      const errorHandler = this.error.bind(this)
-      validatePelelaStructure(sourceCode, filePath, errorHandler)
-      validateNoForbiddenRootAttributes(sourceCode, filePath, errorHandler)
-      validateNoForbiddenHtmlAttributes(sourceCode, filePath, errorHandler)
-      validateComponentAttributes(sourceCode, errorHandler)
-      validateBindingElementRestrictions(sourceCode, errorHandler)
-      validateInputOnlyEvents(sourceCode, errorHandler)
-      validateNoForeignSyntax(sourceCode, filePath, errorHandler)
-      const viewModelName = extractViewModelName(sourceCode, filePath, errorHandler)
+      const viewModelName = validatePelelaSource({
+        sourceCode,
+        filePath: pelelaFilePath,
+        knownComponentTags: getKnownComponentTags(pelelaFilePath),
+        errorFn: this.error.bind(this),
+      })
 
       const escapedTemplate = escapeTemplateForLiteral(sourceCode)
 

--- a/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
@@ -109,6 +109,15 @@ describe('validatePelelaSource', () => {
     )
   })
 
+  it('does not suggest a kebab-case tag when the collapsed component tag is ambiguous', () => {
+    const errors = validateTemplate(
+      pelelaTemplate(`<${PERSON_ROW_COLLAPSED_TAG}></${PERSON_ROW_COLLAPSED_TAG}>`),
+      [PERSON_ROW_TAG, 'personr-ow'],
+    )
+
+    expect(errors).toEqual([])
+  })
+
   it('accepts a known single-word component tag', () => {
     const errors = validateTemplate(pelelaTemplate(`<${COUNTER_TAG}></${COUNTER_TAG}>`), [
       COUNTER_TAG,

--- a/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
@@ -51,6 +51,24 @@ describe('validatePelelaSource', () => {
     expect(errors).toEqual([])
   })
 
+  it('returns the declared view model name when it uses single quotes', () => {
+    const errors: string[] = []
+
+    const viewModelName = validatePelelaSource({
+      sourceCode: `<pelela view-model='${HOME_VIEW_MODEL}'>
+        <${COUNTER_TAG}></${COUNTER_TAG}>
+      </pelela>`,
+      filePath: FILE_PATH,
+      knownComponentTags: [COUNTER_TAG],
+      errorFn: (message) => {
+        errors.push(message)
+      },
+    })
+
+    expect(viewModelName).toBe(HOME_VIEW_MODEL)
+    expect(errors).toEqual([])
+  })
+
   it('reports an error when a component tag uses camelCase', () => {
     const errors = validateTemplate(
       pelelaTemplate(`<${PERSON_ROW_CAMEL_TAG}></${PERSON_ROW_CAMEL_TAG}>`),

--- a/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
@@ -1,0 +1,115 @@
+import { initializeI18n, t } from 'pelelajs'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { validatePelelaSource } from './templateValidation'
+
+const FILE_PATH = '/project/src/home.pelela'
+const HOME_VIEW_MODEL = 'Home'
+const PERSON_ROW_TAG = 'person-row'
+const PERSON_ROW_COLLAPSED_TAG = 'personrow'
+const PERSON_ROW_CAMEL_TAG = 'personRow'
+const PERSON_ROW_PASCAL_TAG = 'PersonRow'
+const COUNTER_TAG = 'counter'
+const INVALID_ATTRIBUTE = 'value'
+
+function pelelaTemplate(content: string): string {
+  return `<pelela view-model="${HOME_VIEW_MODEL}">${content}</pelela>`
+}
+
+function validateTemplate(sourceCode: string, knownComponentTags: string[] = []): string[] {
+  const errors: string[] = []
+
+  validatePelelaSource({
+    sourceCode,
+    filePath: FILE_PATH,
+    knownComponentTags,
+    errorFn: (message) => {
+      errors.push(message)
+    },
+  })
+
+  return errors
+}
+
+describe('validatePelelaSource', () => {
+  beforeEach(() => {
+    initializeI18n('en')
+  })
+
+  it('returns the declared view model name for a valid pelela template', () => {
+    const errors: string[] = []
+
+    const viewModelName = validatePelelaSource({
+      sourceCode: pelelaTemplate(`<${COUNTER_TAG}></${COUNTER_TAG}>`),
+      filePath: FILE_PATH,
+      knownComponentTags: [COUNTER_TAG],
+      errorFn: (message) => {
+        errors.push(message)
+      },
+    })
+
+    expect(viewModelName).toBe(HOME_VIEW_MODEL)
+    expect(errors).toEqual([])
+  })
+
+  it('reports an error when a component tag uses camelCase', () => {
+    const errors = validateTemplate(
+      pelelaTemplate(`<${PERSON_ROW_CAMEL_TAG}></${PERSON_ROW_CAMEL_TAG}>`),
+    )
+
+    expect(errors).toContain(
+      t('errors.compiler.invalidComponentTagCase', {
+        tag: PERSON_ROW_CAMEL_TAG,
+        suggestedTag: PERSON_ROW_TAG,
+      }),
+    )
+  })
+
+  it('reports an error when a component tag uses PascalCase', () => {
+    const errors = validateTemplate(
+      pelelaTemplate(`<${PERSON_ROW_PASCAL_TAG}></${PERSON_ROW_PASCAL_TAG}>`),
+    )
+
+    expect(errors).toContain(
+      t('errors.compiler.invalidComponentTagCase', {
+        tag: PERSON_ROW_PASCAL_TAG,
+        suggestedTag: PERSON_ROW_TAG,
+      }),
+    )
+  })
+
+  it('reports an error when a component tag collapsed a known kebab-case tag', () => {
+    const errors = validateTemplate(
+      pelelaTemplate(`<${PERSON_ROW_COLLAPSED_TAG}></${PERSON_ROW_COLLAPSED_TAG}>`),
+      [PERSON_ROW_TAG],
+    )
+
+    expect(errors).toContain(
+      t('errors.compiler.invalidComponentTagCase', {
+        tag: PERSON_ROW_COLLAPSED_TAG,
+        suggestedTag: PERSON_ROW_TAG,
+      }),
+    )
+  })
+
+  it('accepts a known single-word component tag', () => {
+    const errors = validateTemplate(pelelaTemplate(`<${COUNTER_TAG}></${COUNTER_TAG}>`), [
+      COUNTER_TAG,
+    ])
+
+    expect(errors).toEqual([])
+  })
+
+  it('reports an error when a component attribute does not use a component binding prefix', () => {
+    const errors = validateTemplate(
+      pelelaTemplate(`<${PERSON_ROW_TAG} ${INVALID_ATTRIBUTE}="x"></${PERSON_ROW_TAG}>`),
+      [PERSON_ROW_TAG],
+    )
+
+    expect(errors).toContain(
+      t('errors.compiler.invalidComponentAttribute', {
+        tag: PERSON_ROW_TAG,
+        attr: INVALID_ATTRIBUTE,
+      }),
+    )
+  })
+})

--- a/packages/vite-plugin-pelelajs/src/templateValidation.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.ts
@@ -1,0 +1,318 @@
+import {
+  isPelelaRootTag,
+  isStandardHtmlTag,
+  isValidComponentAttribute,
+  LINK_PREFIX,
+  t,
+} from 'pelelajs'
+
+interface ValidatePelelaSourceParams {
+  sourceCode: string
+  filePath: string
+  knownComponentTags: string[]
+  errorFn: (message: string) => void
+}
+
+const TAG_PATTERN = /<([\w-]+)([^>]*)>/g
+const LINK_ATTRIBUTE_PATTERN = new RegExp(`\\b(${LINK_PREFIX}[a-zA-Z0-9_-]+)\\s*=`, 'g')
+
+export function getPelelaFilePath(filePath: string): string | null {
+  const [cleanFilePath] = filePath.split(/[?#]/)
+  return cleanFilePath.endsWith('.pelela') ? cleanFilePath : null
+}
+
+function extractAttributes(
+  sourceCode: string,
+  attrPattern: RegExp,
+): Array<{ tagName: string; attributeName: string }> {
+  return Array.from(sourceCode.matchAll(TAG_PATTERN)).flatMap((tagMatch) => {
+    const tagName = tagMatch[1].toLowerCase()
+    const attributesSegment = tagMatch[2]
+    return Array.from(attributesSegment.matchAll(attrPattern), (attrMatch) => ({
+      tagName,
+      attributeName: attrMatch[1],
+    }))
+  })
+}
+
+export function extractLinkAttributeMatches(
+  sourceCode: string,
+): Array<{ tagName: string; attributeName: string }> {
+  return extractAttributes(sourceCode, LINK_ATTRIBUTE_PATTERN)
+}
+
+const ATTRIBUTE_PAIR_PATTERN = /([a-zA-Z0-9_-]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?/g
+
+function extractAttributeNames(attributesSegment: string): string[] {
+  return Array.from(attributesSegment.matchAll(ATTRIBUTE_PAIR_PATTERN), (match) => match[1])
+}
+
+function extractComponentAttributeMatches(
+  sourceCode: string,
+): Array<{ tagName: string; attributeName: string }> {
+  return Array.from(sourceCode.matchAll(TAG_PATTERN)).flatMap((tagMatch) =>
+    extractAttributeNames(tagMatch[2]).map((attributeName) => ({
+      tagName: tagMatch[1].toLowerCase(),
+      attributeName,
+    })),
+  )
+}
+
+function validateComponentAttributes(sourceCode: string, errorFn: (message: string) => void): void {
+  const componentMatches = extractComponentAttributeMatches(sourceCode)
+
+  const invalidMatches = componentMatches.filter(
+    (match) =>
+      !isPelelaRootTag(match.tagName) &&
+      !isStandardHtmlTag(match.tagName) &&
+      !isValidComponentAttribute(match.attributeName),
+  )
+
+  invalidMatches.forEach((match) => {
+    errorFn(
+      t('errors.compiler.invalidComponentAttribute', {
+        tag: match.tagName,
+        attr: match.attributeName,
+      }),
+    )
+  })
+}
+
+export function componentTagToKebabCase(tagName: string): string {
+  return tagName
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+}
+
+function validateComponentTagCase(sourceCode: string, errorFn: (message: string) => void): void {
+  Array.from(sourceCode.matchAll(TAG_PATTERN))
+    .map((tagMatch) => tagMatch[1])
+    .filter((tagName) => {
+      const normalizedTagName = tagName.toLowerCase()
+      return (
+        tagName !== normalizedTagName &&
+        !isPelelaRootTag(normalizedTagName) &&
+        !isStandardHtmlTag(normalizedTagName)
+      )
+    })
+    .forEach((tagName) => {
+      errorFn(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: tagName,
+          suggestedTag: componentTagToKebabCase(tagName),
+        }),
+      )
+    })
+}
+
+function extractTemplateTagNames(sourceCode: string): string[] {
+  return Array.from(sourceCode.matchAll(TAG_PATTERN), (tagMatch) => tagMatch[1])
+}
+
+function findCollapsedKebabCaseTag(
+  tagName: string,
+  knownComponentTags: string[],
+): string | undefined {
+  return knownComponentTags.find((knownTag) => knownTag.replace(/-/g, '') === tagName)
+}
+
+function validateCollapsedComponentTags(
+  sourceCode: string,
+  knownComponentTags: string[],
+  errorFn: (message: string) => void,
+): void {
+  extractTemplateTagNames(sourceCode)
+    .filter((tagName) => {
+      const normalizedTagName = tagName.toLowerCase()
+      return (
+        tagName === normalizedTagName &&
+        !tagName.includes('-') &&
+        !isPelelaRootTag(tagName) &&
+        !isStandardHtmlTag(tagName)
+      )
+    })
+    .map((tagName) => ({
+      tagName,
+      suggestedTag: findCollapsedKebabCaseTag(tagName, knownComponentTags),
+    }))
+    .filter(
+      (match): match is { tagName: string; suggestedTag: string } =>
+        match.suggestedTag !== undefined && match.suggestedTag !== match.tagName,
+    )
+    .forEach((match) => {
+      errorFn(
+        t('errors.compiler.invalidComponentTagCase', {
+          tag: match.tagName,
+          suggestedTag: match.suggestedTag,
+        }),
+      )
+    })
+}
+
+function validateNoForbiddenHtmlAttributes(
+  sourceCode: string,
+  filePath: string,
+  errorFn: (message: string) => void,
+): void {
+  const linkMatches = extractLinkAttributeMatches(sourceCode)
+
+  const invalidMatches = linkMatches.filter(
+    (match) => !isPelelaRootTag(match.tagName) && isStandardHtmlTag(match.tagName),
+  )
+
+  invalidMatches.forEach((match) => {
+    errorFn(
+      t('errors.compiler.forbiddenRootAttribute', {
+        filePath,
+        tagName: match.tagName,
+        attr: match.attributeName,
+        snippet: `<${match.tagName} ${match.attributeName}="...">`,
+      }),
+    )
+  })
+}
+
+function validatePelelaStructure(
+  sourceCode: string,
+  filePath: string,
+  errorFn: (message: string) => void,
+): void {
+  const openTags = sourceCode.match(/<(?:pelela|component)\b[^>]*>/gi) || []
+  const closeTags = sourceCode.match(/<\/(?:pelela|component)>/gi) || []
+
+  if (openTags.length === 0) {
+    errorFn(t('errors.compiler.missingRoot', { filePath }))
+  }
+
+  if (openTags.length > 1) {
+    errorFn(t('errors.compiler.multipleRoots', { filePath, count: openTags.length }))
+  }
+
+  if (closeTags.length === 0) {
+    errorFn(t('errors.compiler.missingClosingTag', { filePath }))
+  }
+
+  if (closeTags.length !== openTags.length) {
+    errorFn(t('errors.compiler.unbalancedTags', { filePath }))
+  }
+}
+
+const IMG_ONLY_BINDINGS = ['bind-src', 'bind-alt'] as const
+const INPUT_ONLY_EVENTS = ['enter'] as const
+
+function validateBindingElementRestrictions(
+  sourceCode: string,
+  errorFn: (message: string) => void,
+): void {
+  for (const binding of IMG_ONLY_BINDINGS) {
+    const pattern = new RegExp(
+      `<([a-zA-Z][a-zA-Z0-9]*)\\s[^>]*(?<![a-zA-Z0-9_-])${binding}\\s*=`,
+      'gi',
+    )
+    const matches = sourceCode.matchAll(pattern)
+    for (const match of matches) {
+      const tagName = match[1].toLowerCase()
+      if (tagName !== 'img') {
+        errorFn(t('errors.compiler.onlyForImg', { binding, tag: tagName }))
+      }
+    }
+  }
+}
+
+function validateInputOnlyEvents(sourceCode: string, errorFn: (message: string) => void): void {
+  for (const eventName of INPUT_ONLY_EVENTS) {
+    const pattern = new RegExp(
+      `<([a-zA-Z][a-zA-Z0-9]*)\\s[^>]*(?<![a-zA-Z0-9_-])${eventName}\\s*=`,
+      'gi',
+    )
+    const matches = sourceCode.matchAll(pattern)
+    for (const match of matches) {
+      const tagName = match[1].toLowerCase()
+      if (tagName !== 'input') {
+        errorFn(t('errors.compiler.enterOnlyForInput', { tag: tagName }))
+      }
+    }
+  }
+}
+
+function validateNoForeignSyntax(
+  sourceCode: string,
+  filePath: string,
+  errorFn: (message: string) => void,
+): void {
+  if (/\{\{.*?\}\}/.test(sourceCode)) {
+    errorFn(t('errors.compiler.foreignInterpolation', { filePath }))
+  }
+
+  if (/<[^>]+ \[[^\]]+\]\s*=.*/.test(sourceCode)) {
+    errorFn(t('errors.compiler.foreignPropertyBinding', { filePath }))
+  }
+}
+
+function validateNoForbiddenRootAttributes(
+  sourceCode: string,
+  filePath: string,
+  errorFn: (message: string) => void,
+): void {
+  const rootTagMatch = sourceCode.match(/<(pelela|component)\b([^>]*)>/i)
+  if (!rootTagMatch) return
+
+  const attributes = rootTagMatch[2]
+  const forbiddenPatterns = [
+    new RegExp(`\\b${LINK_PREFIX}[a-zA-Z0-9_-]+`),
+    /\bbind-[a-zA-Z0-9_-]+/,
+    /\bif\s*=/,
+    /\bfor-each\s*=/,
+    /\bclick\s*=/,
+    /\benter\s*=/,
+  ]
+
+  const foundPattern = forbiddenPatterns.find((pattern) => pattern.test(attributes))
+  const foundAttribute = attributes.match(foundPattern ?? '')?.[0]
+
+  if (foundPattern) {
+    errorFn(
+      t('errors.compiler.forbiddenRootAttribute', {
+        filePath,
+        tagName: rootTagMatch[1],
+        attr: foundAttribute,
+        snippet: `<${rootTagMatch[1]} ${foundAttribute}="...">`,
+      }),
+    )
+  }
+}
+
+function extractViewModelName(
+  sourceCode: string,
+  filePath: string,
+  errorFn: (message: string) => void,
+): string {
+  const viewModelMatch = sourceCode.match(/<(?:pelela|component)[^>]*view-model\s*=\s*"([^"]+)"/i)
+  const viewModelName = viewModelMatch ? viewModelMatch[1] : null
+
+  if (!viewModelName) {
+    errorFn(t('errors.compiler.missingViewModel', { filePath }))
+    return ''
+  }
+
+  return viewModelName
+}
+
+export function validatePelelaSource({
+  sourceCode,
+  filePath,
+  knownComponentTags,
+  errorFn,
+}: ValidatePelelaSourceParams): string {
+  validatePelelaStructure(sourceCode, filePath, errorFn)
+  validateComponentTagCase(sourceCode, errorFn)
+  validateCollapsedComponentTags(sourceCode, knownComponentTags, errorFn)
+  validateNoForbiddenRootAttributes(sourceCode, filePath, errorFn)
+  validateNoForbiddenHtmlAttributes(sourceCode, filePath, errorFn)
+  validateComponentAttributes(sourceCode, errorFn)
+  validateBindingElementRestrictions(sourceCode, errorFn)
+  validateInputOnlyEvents(sourceCode, errorFn)
+  validateNoForeignSyntax(sourceCode, filePath, errorFn)
+  return extractViewModelName(sourceCode, filePath, errorFn)
+}

--- a/packages/vite-plugin-pelelajs/src/templateValidation.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.ts
@@ -1,4 +1,5 @@
 import {
+  findUniqueCollapsedTag,
   isPelelaRootTag,
   isStandardHtmlTag,
   isValidComponentAttribute,
@@ -110,13 +111,6 @@ function extractTemplateTagNames(sourceCode: string): string[] {
   return Array.from(sourceCode.matchAll(TAG_PATTERN), (tagMatch) => tagMatch[1])
 }
 
-function findCollapsedKebabCaseTag(
-  tagName: string,
-  knownComponentTags: string[],
-): string | undefined {
-  return knownComponentTags.find((knownTag) => knownTag.replace(/-/g, '') === tagName)
-}
-
 function validateCollapsedComponentTags(
   sourceCode: string,
   knownComponentTags: string[],
@@ -134,7 +128,7 @@ function validateCollapsedComponentTags(
     })
     .map((tagName) => ({
       tagName,
-      suggestedTag: findCollapsedKebabCaseTag(tagName, knownComponentTags),
+      suggestedTag: findUniqueCollapsedTag(tagName, knownComponentTags),
     }))
     .filter(
       (match): match is { tagName: string; suggestedTag: string } =>

--- a/packages/vite-plugin-pelelajs/src/templateValidation.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.ts
@@ -288,8 +288,10 @@ function extractViewModelName(
   filePath: string,
   errorFn: (message: string) => void,
 ): string {
-  const viewModelMatch = sourceCode.match(/<(?:pelela|component)[^>]*view-model\s*=\s*"([^"]+)"/i)
-  const viewModelName = viewModelMatch ? viewModelMatch[1] : null
+  const viewModelMatch = sourceCode.match(
+    /<(?:pelela|component)[^>]*view-model\s*=\s*(?:"([^"]+)"|'([^']+)')/i,
+  )
+  const viewModelName = viewModelMatch?.[1] ?? viewModelMatch?.[2] ?? null
 
   if (!viewModelName) {
     errorFn(t('errors.compiler.missingViewModel', { filePath }))


### PR DESCRIPTION
## Qué cambia

Este PR mejora el mensaje de error cuando se usa un componente con un tag que no está en kebab-case dentro de un archivo `.pelela`.

Ahora, en lugar de terminar con un error genérico de componente desconocido, Pelela muestra un mensaje específico indicando cuál es el tag esperado. Por ejemplo, si se escribe `<personRow>` o el navegador lo normaliza como `<personrow>`, el error sugiere usar `<person-row>`.

## Nota técnica

La validación principal se hace en el plugin de Vite porque en ese punto todavía tenemos el contenido original del archivo `.pelela` y podemos detectar tags como `<personRow>` o `<PersonRow>` antes de que HTML los normalice a minúsculas.

También queda un fallback en runtime para el caso en que el template ya llegue normalizado como `<personrow>`, evitando que termine en el error genérico de componente desconocido.

## Tests

Se agregaron tests para cubrir:

- Tags de componentes en camelCase.
- Tags de componentes en PascalCase.
- Tags ya normalizados por HTML, como `<personrow>`, cuando existe un componente registrado como `<person-row>`.
- Componentes válidos de una sola palabra, como `<counter>`.
- Validaciones directas de `validatePelelaSource`.

## Captura

El error ahora muestra la sugerencia correcta para usar el tag en kebab-case.

<img width="1225" height="115" alt="image" src="https://github.com/user-attachments/assets/a6d4899a-c3d1-4eba-8bc3-d7379ee5b5ba" />

## Fixes #141