### PR TITLE
Fix forbidden attribute message for internal HTML tags

### DIFF
--- a/packages/core/src/commons/locales/en.ts
+++ b/packages/core/src/commons/locales/en.ts
@@ -69,7 +69,9 @@ const errors = {
       'Component <{{tag}}>: parent property "{{parentKey}}" does not exist in parent view model',
     missingViewModel: 'Pelela template "{{filePath}}" must contain view-model="..." attribute',
     forbiddenRootAttribute:
-      'Pelela template "{{filePath}}": Attribute "{{attr}}" is not allowed on root tag <{{tagName}}>. Logic and binding attributes can only be used on internal elements or component invocations.',
+      'Pelela template "{{filePath}}": Attribute "{{attr}}" is not allowed on root tag <{{tagName}}>. Logic and binding attributes can only be used on internal elements or component invocations. Found at: {{snippet}}',
+    forbiddenHtmlAttribute:
+      'Pelela template "{{filePath}}": Attribute "{{attr}}" is not allowed on HTML tag <{{tagName}}>. Logic and binding attributes can only be used on component invocations. Found at: {{snippet}}',
     directiveOutsideRoot:
       'Pelela template "{{filePath}}": Directive `{{directive}}` detected outside root tag <{{tagName}}>. Found at: {{snippet}}',
     unknownComponent:

--- a/packages/core/src/commons/locales/es.ts
+++ b/packages/core/src/commons/locales/es.ts
@@ -73,7 +73,9 @@ const errors = {
       'Componente <{{tag}}>: la propiedad padre "{{parentKey}}" no existe en el view model padre',
     missingViewModel: 'Pelela template "{{filePath}}" debe contener atributo view-model="..."',
     forbiddenRootAttribute:
-      'Pelela template "{{filePath}}": El atributo "{{attr}}" no está permitido en la etiqueta raíz <{{tagName}}>. Los atributos de lógica y binding solo pueden usarse en elementos internos o invocaciones de componentes.',
+      'Pelela template "{{filePath}}": El atributo "{{attr}}" no está permitido en la etiqueta raíz <{{tagName}}>. Los atributos de lógica y binding solo pueden usarse en elementos internos o invocaciones de componentes. Encontrado en: {{snippet}}',
+    forbiddenHtmlAttribute:
+      'Pelela template "{{filePath}}": El atributo "{{attr}}" no está permitido en la etiqueta HTML <{{tagName}}>. Los atributos de lógica y binding solo pueden usarse en invocaciones de componentes. Encontrado en: {{snippet}}',
     directiveOutsideRoot:
       'Pelela template "{{filePath}}": Directiva `{{directive}}` detectada fuera de la etiqueta raíz <{{tagName}}>. Encontrado en: {{snippet}}',
     unknownComponent:

--- a/packages/core/src/commons/locales/translationSchema.ts
+++ b/packages/core/src/commons/locales/translationSchema.ts
@@ -51,6 +51,7 @@ type ErrorTranslations = {
     missingParentProperty: string
     missingViewModel: string
     forbiddenRootAttribute: string
+    forbiddenHtmlAttribute: string
     directiveOutsideRoot: string
     unknownComponent: string
     unknownComponentProperty: string

--- a/packages/vite-plugin-pelelajs/src/index.test.ts
+++ b/packages/vite-plugin-pelelajs/src/index.test.ts
@@ -407,7 +407,7 @@ describe('pelelajsPlugin', () => {
       handler.call({ error: errorFn } as never, pelelaPath, {} as never)
 
       expect(errors).toContain(
-        t('errors.compiler.forbiddenRootAttribute', {
+        t('errors.compiler.forbiddenHtmlAttribute', {
           filePath: pelelaPath,
           tagName: 'div',
           attr: 'link-value',

--- a/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.test.ts
@@ -9,7 +9,10 @@ const PERSON_ROW_COLLAPSED_TAG = 'personrow'
 const PERSON_ROW_CAMEL_TAG = 'personRow'
 const PERSON_ROW_PASCAL_TAG = 'PersonRow'
 const COUNTER_TAG = 'counter'
+const PELELA_ROOT_TAG = 'pelela'
+const HTML_TAG = 'div'
 const INVALID_ATTRIBUTE = 'value'
+const LINK_ATTRIBUTE = 'link-value'
 
 function pelelaTemplate(content: string): string {
   return `<pelela view-model="${HOME_VIEW_MODEL}">${content}</pelela>`
@@ -138,5 +141,38 @@ describe('validatePelelaSource', () => {
         attr: INVALID_ATTRIBUTE,
       }),
     )
+  })
+
+  it('reports a root-specific error when a forbidden attribute is on the root tag', () => {
+    const errors = validateTemplate(
+      [
+        `<${PELELA_ROOT_TAG} view-model="${HOME_VIEW_MODEL}" ${LINK_ATTRIBUTE}="x">`,
+        `</${PELELA_ROOT_TAG}>`,
+      ].join(''),
+    )
+
+    expect(errors).toEqual([
+      t('errors.compiler.forbiddenRootAttribute', {
+        filePath: FILE_PATH,
+        tagName: PELELA_ROOT_TAG,
+        attr: LINK_ATTRIBUTE,
+        snippet: `<${PELELA_ROOT_TAG} ${LINK_ATTRIBUTE}="...">`,
+      }),
+    ])
+  })
+
+  it('reports an HTML-specific error when a forbidden attribute is on an internal HTML tag', () => {
+    const errors = validateTemplate(
+      pelelaTemplate(`<${HTML_TAG} ${LINK_ATTRIBUTE}="x"></${HTML_TAG}>`),
+    )
+
+    expect(errors).toEqual([
+      t('errors.compiler.forbiddenHtmlAttribute', {
+        filePath: FILE_PATH,
+        tagName: HTML_TAG,
+        attr: LINK_ATTRIBUTE,
+        snippet: `<${HTML_TAG} ${LINK_ATTRIBUTE}="...">`,
+      }),
+    ])
   })
 })

--- a/packages/vite-plugin-pelelajs/src/templateValidation.ts
+++ b/packages/vite-plugin-pelelajs/src/templateValidation.ts
@@ -157,7 +157,7 @@ function validateNoForbiddenHtmlAttributes(
 
   invalidMatches.forEach((match) => {
     errorFn(
-      t('errors.compiler.forbiddenRootAttribute', {
+      t('errors.compiler.forbiddenHtmlAttribute', {
         filePath,
         tagName: match.tagName,
         attr: match.attributeName,


### PR DESCRIPTION
## Resumen

Se agrega un mensaje i18n específico para atributos prohibidos en tags HTML internos, evitando reutilizar el error de atributos prohibidos en el tag raíz.

## Cambios

- Mantiene `forbiddenRootAttribute` solo para el tag raíz.
- Agrega `forbiddenHtmlAttribute` para tags HTML internos.
- Cubre ambos casos con tests específicos.

## Closes #144