### PR TITLE
Ejecutar tests de VS Code en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run tests with coverage
         run: pnpm test:coverage
 
+      - name: Run VS Code extension tests
+        run: pnpm test:vscode
+
       - name: Verify coverage files exist
         if: always()
         run: |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage",
     "test:packages": "pnpm -r run test",
     "test:vscode": "pnpm -C tools/pelela-vscode test",
-    "test:all": "pnpm run test:packages && pnpm run test:vscode",
+    "test:all": "pnpm run test --run && pnpm run test:vscode",
     "biome:lint": "biome lint .",
     "biome:lint:fix": "biome lint --write .",
     "biome:format": "biome format .",
@@ -25,7 +25,7 @@
     "release:npm": "tsx scripts/check-npm-auth.ts && release-it",
     "release:vscode": "tsx scripts/check-vscode-auth.ts && pnpm -C tools/pelela-vscode run release",
     "audit": "pnpm audit --audit-level moderate",
-    "ci:local": "pnpm install && pnpm run biome:check && pnpm run typecheck && pnpm run build && pnpm run test:coverage",
+    "ci:local": "pnpm install && pnpm run biome:check && pnpm run typecheck && pnpm run build && pnpm run test:coverage && pnpm run test:vscode",
     "ci:act": "act -j ci"
   },
   "keywords": [],

--- a/tools/pelela-vscode/test/diagnostics/attributeValidator.test.ts
+++ b/tools/pelela-vscode/test/diagnostics/attributeValidator.test.ts
@@ -52,9 +52,15 @@ describe('attributeValidator', () => {
       assert.strictEqual(validateUnknownAttributes(tags).length, 0)
     })
 
-    it('allows on-* event handler attribute', () => {
+    it('rejects HTML event handler attribute', () => {
       const tags = prepareTags(['<div onclick="handler">'])
-      assert.strictEqual(validateUnknownAttributes(tags).length, 0)
+      const diagnostics = validateUnknownAttributes(tags)
+      assert.strictEqual(diagnostics.length, 1)
+      assertDiagnostic(
+        diagnostics[0],
+        t('diagnostics.unknownAttribute', { name: 'onclick' }),
+        vscode.DiagnosticSeverity.Warning
+      )
     })
 
     it('allows colspan', () => {


### PR DESCRIPTION
## Qué cambia

- ejecuta la suite de tests de la extensión VS Code en GitHub Actions y en `ci:local`
- actualiza `test:all` para cubrir el proyecto Vitest raíz y la suite de VS Code
- corrige la expectativa desactualizada de `onclick`

## Motivo

El CI solo ejecutaba los proyectos de Vitest. La suite de Mocha de `tools/pelela-vscode` quedaba afuera, por lo que una PR podía tener checks verdes aunque los tests de la extensión fallaran.

## Validación

- [x] `pnpm run test:all`
- [x] `pnpm run biome:check`

Closes #157
