### PR TITLE
Fix #165 - routing errors are rendered as undefined

### DIFF
--- a/packages/core/src/bootstrap/mountTemplate.ts
+++ b/packages/core/src/bootstrap/mountTemplate.ts
@@ -105,18 +105,25 @@ function validateNoComponentsOutsideRoot(templateHtml: string): void {
 const ERROR_PAGE_CSS = `
 @import 'https://fonts.googleapis.com/css2?family=Geist:ital,wght@0,100..900;1,100..900&display=swap';
 
+/* The application stylesheet is still loaded, so every property that could constrain the
+   error page has to be reset explicitly, not just the ones we set. */
 body {
+  box-sizing: border-box;
   font-family: Geist, sans-serif;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   margin: 0;
   padding: 40px 20px;
+  max-width: none;
+  width: auto;
   min-height: 100vh;
+  text-align: left;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .error-container {
+  box-sizing: border-box;
   background: white;
   border-radius: 12px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -38,6 +38,7 @@ const DETAIL_TEMPLATE =
 const NOT_FOUND_TEMPLATE =
   '<pelela view-model="NotFoundPage"><p bind-content="message"></p></pelela>'
 const UNMATCHED_PATH = '/nonexistent'
+const ROUTE_NOT_FOUND_IN_ENGLISH = `[pelela] No route defined for "${UNMATCHED_PATH}"`
 
 function registerTestComponents(): void {
   defineComponent('ProductCatalog', ProductCatalog, CATALOG_TEMPLATE)
@@ -149,7 +150,7 @@ describe('router', () => {
 
       expect(handleErrorSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: t('errors.routing.routeNotFound', { path: UNMATCHED_PATH }),
+          message: ROUTE_NOT_FOUND_IN_ENGLISH,
         }),
       )
     })

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -116,14 +116,19 @@ describe('router', () => {
       expect(addSpy).toHaveBeenCalledTimes(2)
     })
 
-    it('should report a RoutingError when start URL does not match any route', () => {
+    it('should report a RoutingError with the translated message when start URL does not match', () => {
       const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
       registerTestComponents()
       window.history.replaceState(null, '', UNMATCHED_PATH)
 
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      expect(handleErrorSpy).toHaveBeenCalledWith(expect.any(RoutingError))
+      expect(handleErrorSpy).toHaveBeenCalledTimes(1)
+
+      const [reportedError] = handleErrorSpy.mock.calls[0]
+
+      expect(reportedError).toBeInstanceOf(RoutingError)
+      expect((reportedError as RoutingError).message).toBe(ROUTE_NOT_FOUND_IN_ENGLISH)
     })
 
     /**
@@ -141,23 +146,9 @@ describe('router', () => {
       expect(initializeI18nSpy).toHaveBeenCalledBefore(handleErrorSpy)
     })
 
-    it('should report a translated message when start URL does not match any route', () => {
-      const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
-      registerTestComponents()
-      window.history.replaceState(null, '', UNMATCHED_PATH)
-
-      router.start(container, [{ path: '/', component: ProductCatalog }])
-
-      expect(handleErrorSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: ROUTE_NOT_FOUND_IN_ENGLISH,
-        }),
-      )
-    })
-
     it('should reset isRouterActive when route resolution fails', () => {
       registerTestComponents()
-      window.history.replaceState(null, '', '/nonexistent')
+      window.history.replaceState(null, '', UNMATCHED_PATH)
 
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
@@ -198,7 +189,7 @@ describe('router', () => {
       registerTestComponents()
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      router.navigateTo('/unknown')
+      router.navigateTo(UNMATCHED_PATH)
 
       expect(handleErrorSpy).toHaveBeenCalledWith(expect.any(RoutingError))
     })
@@ -207,7 +198,7 @@ describe('router', () => {
       registerTestComponents()
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      router.navigateTo('/unknown')
+      router.navigateTo(UNMATCHED_PATH)
 
       expect(getRouterActive()).toBe(false)
     })
@@ -246,7 +237,7 @@ describe('router', () => {
       const initialPath = window.location.pathname
 
       try {
-        router.navigateTo('/unknown')
+        router.navigateTo(UNMATCHED_PATH)
       } catch {
         // Ignored, we want to check the URL
       }

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -47,7 +47,6 @@ function registerTestComponents(): void {
 
 describe('router', () => {
   let container: HTMLElement
-  let renderErrorPageSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     resetRouter()
@@ -56,7 +55,6 @@ describe('router', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     window.history.replaceState(null, '', '/')
-    renderErrorPageSpy = vi.spyOn(mountTemplate, 'renderErrorPage')
   })
 
   afterEach(() => {
@@ -115,41 +113,41 @@ describe('router', () => {
       expect(removeSpy).toHaveBeenCalledWith('popstate', expect.any(Function))
       // Total adds: one for each start
       expect(addSpy).toHaveBeenCalledTimes(2)
-
-      addSpy.mockRestore()
-      removeSpy.mockRestore()
     })
 
-    it('should render error page when start URL does not match any route', () => {
+    it('should report a RoutingError when start URL does not match any route', () => {
+      const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
       registerTestComponents()
-      window.history.replaceState(null, '', '/nonexistent')
+      window.history.replaceState(null, '', UNMATCHED_PATH)
 
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      expect(renderErrorPageSpy).toHaveBeenCalledWith(expect.any(RoutingError))
+      expect(handleErrorSpy).toHaveBeenCalledWith(expect.any(RoutingError))
     })
 
     /**
      * Route resolution fails before bootstrap() or mountTemplate() run, and those were the
      * only ones initializing i18n, so every message rendered as "undefined".
      */
-    it('should initialize i18n before rendering a route resolution error', () => {
+    it('should initialize i18n before reporting a route resolution error', () => {
       const initializeI18nSpy = vi.spyOn(i18n, 'initializeI18n')
+      const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
       registerTestComponents()
       window.history.replaceState(null, '', UNMATCHED_PATH)
 
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      expect(initializeI18nSpy).toHaveBeenCalledBefore(renderErrorPageSpy)
+      expect(initializeI18nSpy).toHaveBeenCalledBefore(handleErrorSpy)
     })
 
-    it('should render error page with a translated message when start URL does not match any route', () => {
+    it('should report a translated message when start URL does not match any route', () => {
+      const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
       registerTestComponents()
       window.history.replaceState(null, '', UNMATCHED_PATH)
 
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      expect(renderErrorPageSpy).toHaveBeenCalledWith(
+      expect(handleErrorSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           message: t('errors.routing.routeNotFound', { path: UNMATCHED_PATH }),
         }),
@@ -194,12 +192,14 @@ describe('router', () => {
       expect(window.location.pathname).toBe('/product/42')
     })
 
-    it('should call renderErrorPage when navigating to an undefined route', () => {
+    it('should report a RoutingError when navigating to an undefined route', () => {
+      const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
       registerTestComponents()
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
       router.navigateTo('/unknown')
-      expect(renderErrorPageSpy).toHaveBeenCalledWith(expect.any(RoutingError))
+
+      expect(handleErrorSpy).toHaveBeenCalledWith(expect.any(RoutingError))
     })
 
     it('should reset isRouterActive when navigating to an undefined route', () => {
@@ -216,31 +216,26 @@ describe('router', () => {
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
       const handleErrorSpy = vi.spyOn(mountTemplate, 'handleError')
-      const mountTemplateSpy = vi.spyOn(mountTemplate, 'mountTemplate').mockImplementation(() => {
+      vi.spyOn(mountTemplate, 'mountTemplate').mockImplementation(() => {
         throw new Error('Mount failed')
       })
 
       router.navigateTo('/')
 
       expect(handleErrorSpy).toHaveBeenCalledWith(expect.any(Error))
-
-      mountTemplateSpy.mockRestore()
-      handleErrorSpy.mockRestore()
     })
 
     it('should reset isRouterActive when mountTemplate throws during navigateTo', () => {
       registerTestComponents()
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
-      const mountTemplateSpy = vi.spyOn(mountTemplate, 'mountTemplate').mockImplementation(() => {
+      vi.spyOn(mountTemplate, 'mountTemplate').mockImplementation(() => {
         throw new Error('Mount failed')
       })
 
       router.navigateTo('/')
 
       expect(getRouterActive()).toBe(false)
-
-      mountTemplateSpy.mockRestore()
     })
 
     it('should NOT update the browser URL when navigation fails (atomicity)', () => {

--- a/packages/core/src/router/router.test.ts
+++ b/packages/core/src/router/router.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getRouterActive, setRouterActive } from '../bootstrap/bootstrap'
 import * as mountTemplate from '../bootstrap/mountTemplate'
+import * as i18n from '../commons/i18n'
 import { t } from '../commons/i18n'
 import { RoutingError } from '../errors/index'
 import { clearComponentRegistry, defineComponent } from '../registry/componentRegistry'
@@ -36,6 +37,7 @@ const DETAIL_TEMPLATE =
   '<pelela view-model="ProductDetail"><p bind-content="name"></p><img bind-src="imageUrl" /></pelela>'
 const NOT_FOUND_TEMPLATE =
   '<pelela view-model="NotFoundPage"><p bind-content="message"></p></pelela>'
+const UNMATCHED_PATH = '/nonexistent'
 
 function registerTestComponents(): void {
   defineComponent('ProductCatalog', ProductCatalog, CATALOG_TEMPLATE)
@@ -125,6 +127,33 @@ describe('router', () => {
       router.start(container, [{ path: '/', component: ProductCatalog }])
 
       expect(renderErrorPageSpy).toHaveBeenCalledWith(expect.any(RoutingError))
+    })
+
+    /**
+     * Route resolution fails before bootstrap() or mountTemplate() run, and those were the
+     * only ones initializing i18n, so every message rendered as "undefined".
+     */
+    it('should initialize i18n before rendering a route resolution error', () => {
+      const initializeI18nSpy = vi.spyOn(i18n, 'initializeI18n')
+      registerTestComponents()
+      window.history.replaceState(null, '', UNMATCHED_PATH)
+
+      router.start(container, [{ path: '/', component: ProductCatalog }])
+
+      expect(initializeI18nSpy).toHaveBeenCalledBefore(renderErrorPageSpy)
+    })
+
+    it('should render error page with a translated message when start URL does not match any route', () => {
+      registerTestComponents()
+      window.history.replaceState(null, '', UNMATCHED_PATH)
+
+      router.start(container, [{ path: '/', component: ProductCatalog }])
+
+      expect(renderErrorPageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: t('errors.routing.routeNotFound', { path: UNMATCHED_PATH }),
+        }),
+      )
     })
 
     it('should reset isRouterActive when route resolution fails', () => {

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -204,9 +204,9 @@ export const router = {
   /**
    * Configures the router and mounts the route matching the current URL.
    * All components must be registered with defineComponent() before calling start().
+   * Initializes i18n first, so errors thrown before the first mount have a message.
    */
   start(rootContainer: HTMLElement, routeDefs: RouteDefinition[]): void {
-    // Route resolution can fail before any mount, and those errors need a translated message.
     initializeI18n()
 
     if (popstateHandler) {

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -6,7 +6,7 @@ import {
   removeStylesheetLinks,
 } from '../commons/cssLoader'
 import { toKebabCase } from '../commons/helpers'
-import { t } from '../commons/i18n'
+import { initializeI18n, t } from '../commons/i18n'
 import { RoutingError } from '../errors/RoutingError'
 import {
   getComponentByTag,
@@ -206,6 +206,9 @@ export const router = {
    * All components must be registered with defineComponent() before calling start().
    */
   start(rootContainer: HTMLElement, routeDefs: RouteDefinition[]): void {
+    // Route resolution can fail before any mount, and those errors need a translated message.
+    initializeI18n()
+
     if (popstateHandler) {
       window.removeEventListener('popstate', popstateHandler)
     }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineProject({
     name: 'core',
     environment: 'jsdom',
     setupFiles: ['./test-setup.ts'],
+    restoreMocks: true,
   },
 })


### PR DESCRIPTION
Closes #165

## Qué pasaba

`initializeI18n()` sólo se llamaba desde `mountTemplate()` y `bootstrap()` pero no en `router.start()`. `RoutingError` armaba su mensaje contra un `i18next` sin inicializar y `t()` devolvía `undefined`.

## Cambios

- `router.start()` inicializa i18n como primera sentencia, igual que ya lo hacen
  `bootstrap()` y `mountTemplate()` en sus propios puntos de entrada.

## Captura

<img width="2352" height="1792" alt="localhost_5173_sarasa" src="https://github.com/user-attachments/assets/fe7f298c-b023-4a3d-ae3b-df358b92b4b3" />